### PR TITLE
feat: validate the GitHub alert signature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
 	"name": "GitHub secret scanning",
 	"image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.11",
 	"remoteEnv": {
-		"PATH": "/home/vscode/.local/bin:${containerEnv:PATH}" // give our installed Python modules precedence
+		"PATH": "/home/vscode/.local/bin:${containerEnv:PATH}", // give our installed Python modules precedence
+		"PYTHONPATH": "./api"
 	},
 	"containerEnv": {
 		"SHELL": "/bin/zsh"
@@ -26,18 +27,19 @@
 			],
 			"settings": {
 				"python.pythonPath": "/usr/local/bin/python",
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
 				"python.linting.enabled": true,
 				"python.linting.pylintEnabled": true,
 				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"python.formatting.blackPath": "/home/vscode/.local/bin/black",
 				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
 				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+				"python.linting.flake8Path": "/home/vscode/.local/bin/flake8",
 				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
 				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
 				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
 				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-				"python.analysis.extraPaths": ["api"],
+				"python.autoComplete.extraPaths": ["./api"],
 				"[python]": {
 					"editor.formatOnSave": true
 				},

--- a/api/main.py
+++ b/api/main.py
@@ -6,8 +6,8 @@ from routers import alerts, ops
 
 
 app = FastAPI(
-    title="API GitHub Secret Scanning",
-    description="API to receive GitHub secret scanning alerts",
+    title="GitHub Secret Scanning Alerts API",
+    description="Receives alerts from GitHub when they detect a secret in a repository",
     version="1.0.0",
 )
 

--- a/api/main.py
+++ b/api/main.py
@@ -2,15 +2,8 @@
 Main API entrypoint
 """
 from fastapi import FastAPI
-from dotenv import load_dotenv
-
 from routers import alerts, ops
-from utils.helpers import get_env_var
 
-load_dotenv()
-
-GITHUB_PUBLIC_KEYS_URL = get_env_var("GITHUB_PUBLIC_KEYS_URL")
-GITHUB_TOKEN = get_env_var("GITHUB_TOKEN")
 
 app = FastAPI(
     title="API GitHub Secret Scanning",

--- a/api/models/Alert.py
+++ b/api/models/Alert.py
@@ -1,0 +1,12 @@
+"""
+GitHub secret alert
+"""
+from pydantic import BaseModel  # pylint: disable=no-name-in-module
+
+
+class Alert(BaseModel):
+    "GitHub secret alert"
+    token: str
+    type: str
+    url: str
+    source: str

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+env =  
+    GITHUB_PUBLIC_KEYS_URL=https://api.github.com/meta/public_keys/secret_scanning
+    GITHUB_TOKEN=your-github-token

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,4 +2,3 @@ cryptography==39.0.1
 fastapi==0.91.0
 python-dotenv==0.21.1
 requests==2.28.2
-rsa==4.9

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,2 +1,5 @@
+cryptography==39.0.1
 fastapi==0.91.0
 python-dotenv==0.21.1
+requests==2.28.2
+rsa==4.9

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -1,6 +1,7 @@
 black==23.1.0
 coverage==7.1.0
 flake8==6.0.0
+httpx==0.23.3
 pytest==7.2.1
 pytest-env==0.8.1
 uvicorn==0.20.0

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -2,4 +2,5 @@ black==23.1.0
 coverage==7.1.0
 flake8==6.0.0
 pytest==7.2.1
+pytest-env==0.8.1
 uvicorn==0.20.0

--- a/api/routers/alerts.py
+++ b/api/routers/alerts.py
@@ -1,12 +1,24 @@
 """
 API routes for the GitHub alerts requests
 """
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Request, Response, status
+from utils.helpers import is_valid_signature
+from utils.logger import logger
 
 router = APIRouter()
 
 
 @router.post("/alert", status_code=status.HTTP_201_CREATED)
-def receive_alert():
+def receive_alert(request: Request, response: Response):
     "Request from GitHub that a secret has been detected"
-    return {"status": "OK"}
+
+    public_key_id = request.headers.get("GITHUB-PUBLIC-KEY-IDENTIFIER")
+    public_key_signature = request.headers.get("GITHUB-PUBLIC-KEY-SIGNATURE")
+    payload = request.body
+
+    if is_valid_signature(public_key_id, public_key_signature, payload):
+        logger.info("%s", payload)
+        return {"status": "OK"}
+
+    response.status_code = status.HTTP_400_BAD_REQUEST
+    return {"status": "ERROR"}

--- a/api/routers/alerts.py
+++ b/api/routers/alerts.py
@@ -2,7 +2,7 @@
 API routes for the GitHub alerts requests
 """
 from fastapi import APIRouter, Request, Response, status
-from utils.helpers import is_valid_signature
+from utils.crypto import is_valid_signature
 from utils.logger import logger
 
 router = APIRouter()

--- a/api/routers/alerts.py
+++ b/api/routers/alerts.py
@@ -1,7 +1,7 @@
 """
 API routes for the GitHub alerts requests
 """
-from fastapi import APIRouter, Body, Request, Response, status
+from fastapi import APIRouter, Request, Response, status
 from utils.crypto import is_valid_signature
 from utils.logger import logger
 
@@ -9,11 +9,14 @@ router = APIRouter()
 
 
 @router.post("/alert", status_code=status.HTTP_201_CREATED)
-async def receive_alert(request: Request, response: Response, payload: str = Body(...)):
+async def receive_alert(request: Request, response: Response):
     "Request from GitHub that a secret has been detected"
 
     public_key_id = request.headers.get("GITHUB-PUBLIC-KEY-IDENTIFIER")
     public_key_signature = request.headers.get("GITHUB-PUBLIC-KEY-SIGNATURE")
+
+    raw_payload = await request.body()
+    payload = raw_payload.decode("utf-8")
 
     if is_valid_signature(public_key_id, public_key_signature, payload):
         logger.info("%s", payload)

--- a/api/routers/alerts.py
+++ b/api/routers/alerts.py
@@ -1,7 +1,9 @@
 """
 API routes for the GitHub alerts requests
 """
+from typing import List
 from fastapi import APIRouter, Request, Response, status
+from models.Alert import Alert
 from utils.crypto import is_valid_signature
 from utils.logger import logger
 
@@ -9,17 +11,19 @@ router = APIRouter()
 
 
 @router.post("/alert", status_code=status.HTTP_201_CREATED)
-async def receive_alert(request: Request, response: Response):
+async def receive_alert(request: Request, response: Response, alerts: List[Alert]):
     "Request from GitHub that a secret has been detected"
 
-    public_key_id = request.headers.get("GITHUB-PUBLIC-KEY-IDENTIFIER")
-    public_key_signature = request.headers.get("GITHUB-PUBLIC-KEY-SIGNATURE")
-
+    # The raw string request body is needed to validate the signature
     raw_payload = await request.body()
     payload = raw_payload.decode("utf-8")
 
+    # Make sure the request came from GitHub
+    public_key_id = request.headers.get("GITHUB-PUBLIC-KEY-IDENTIFIER")
+    public_key_signature = request.headers.get("GITHUB-PUBLIC-KEY-SIGNATURE")
     if is_valid_signature(public_key_id, public_key_signature, payload):
-        logger.info("%s", payload)
+        for alert in alerts:
+            logger.warning("Secret detected: %s", alert)
         return {"status": "OK"}
 
     response.status_code = status.HTTP_400_BAD_REQUEST

--- a/api/routers/alerts.py
+++ b/api/routers/alerts.py
@@ -1,7 +1,7 @@
 """
 API routes for the GitHub alerts requests
 """
-from fastapi import APIRouter, Request, Response, status
+from fastapi import APIRouter, Body, Request, Response, status
 from utils.crypto import is_valid_signature
 from utils.logger import logger
 
@@ -9,16 +9,15 @@ router = APIRouter()
 
 
 @router.post("/alert", status_code=status.HTTP_201_CREATED)
-def receive_alert(request: Request, response: Response):
+async def receive_alert(request: Request, response: Response, payload: str = Body(...)):
     "Request from GitHub that a secret has been detected"
 
     public_key_id = request.headers.get("GITHUB-PUBLIC-KEY-IDENTIFIER")
     public_key_signature = request.headers.get("GITHUB-PUBLIC-KEY-SIGNATURE")
-    payload = request.body
 
     if is_valid_signature(public_key_id, public_key_signature, payload):
         logger.info("%s", payload)
         return {"status": "OK"}
 
     response.status_code = status.HTTP_400_BAD_REQUEST
-    return {"status": "ERROR"}
+    return {"status": "ERROR", "payload": payload}

--- a/api/routers/ops.py
+++ b/api/routers/ops.py
@@ -3,6 +3,7 @@ API routes for operation requests
 """
 from os import environ
 from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse
 
 router = APIRouter()
 
@@ -17,3 +18,14 @@ def version():
 def healthcheck():
     "Simple healthcheck to check the service is running"
     return {"status": "OK"}
+
+
+@router.get("/.well-known/security.txt", response_class=PlainTextResponse)
+def security():
+    "Security.txt file"
+    return """Contact: mailto:security-securite@cds-snc.ca
+Preferred-Languages: en, fr
+Policy: https://digital.canada.ca/legal/security-notice
+Hiring: https://digital.canada.ca/join-our-team/
+Hiring: https://numerique.canada.ca/rejoindre-notre-equipe/
+"""

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,9 @@
+# pylint: disable=missing-docstring,line-too-long
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+
+
+@pytest.fixture(scope="session")
+def client() -> TestClient:
+    yield TestClient(app)

--- a/api/tests/routers/test_alerts.py
+++ b/api/tests/routers/test_alerts.py
@@ -1,0 +1,60 @@
+# pylint: disable=missing-docstring,line-too-long
+from unittest.mock import call, patch
+from fastapi import status
+from models.Alert import Alert
+
+
+def test_homepage_404(client):
+    response = client.get("/")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@patch("main.alerts.is_valid_signature")
+@patch("main.alerts.logger")
+def test_alert_valid_signature(mock_logger, mock_is_valid_signature, client):
+    mock_is_valid_signature.return_value = True
+    response = client.post(
+        "/alert",
+        json=[
+            {"token": "ring", "type": "frodo", "url": "baggins", "source": "shire"},
+            {
+                "token": "po-ta-toes",
+                "type": "samwise",
+                "url": "gamgee",
+                "source": "shire",
+            },
+        ],
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == {"status": "OK"}
+    assert mock_logger.warning.call_count == 2
+    mock_logger.warning.assert_has_calls(
+        [
+            call(
+                "Secret detected: %s",
+                Alert(token="ring", type="frodo", url="baggins", source="shire"),
+            ),
+            call(
+                "Secret detected: %s",
+                Alert(token="po-ta-toes", type="samwise", url="gamgee", source="shire"),
+            ),
+        ]
+    )
+
+
+@patch("main.alerts.is_valid_signature")
+def test_alert_invalid_signature(mock_is_valid_signature, client):
+    mock_is_valid_signature.return_value = False
+    response = client.post(
+        "/alert", json=[{"token": "foo", "type": "bar", "url": "bam", "source": "baz"}]
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "status": "ERROR",
+        "payload": '[{"token": "foo", "type": "bar", "url": "bam", "source": "baz"}]',
+    }
+
+
+def test_alert_bad_data(client):
+    response = client.post("/alert", json={"foo": "bar"})
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/api/tests/routers/test_ops.py
+++ b/api/tests/routers/test_ops.py
@@ -1,0 +1,31 @@
+# pylint: disable=missing-docstring,line-too-long
+from os import environ
+from unittest.mock import patch
+from fastapi import status
+
+
+@patch.dict(environ, {"GIT_SHA": "mmmsha"})
+def test_version(client):
+    response = client.get("/version")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["version"] == "mmmsha"
+
+
+def test_healthcheck(client):
+    response = client.get("/healthcheck")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == "OK"
+
+
+def test_security(client):
+    response = client.get("/.well-known/security.txt")
+    assert response.status_code == status.HTTP_200_OK
+    assert (
+        response.text
+        == """Contact: mailto:security-securite@cds-snc.ca
+Preferred-Languages: en, fr
+Policy: https://digital.canada.ca/legal/security-notice
+Hiring: https://digital.canada.ca/join-our-team/
+Hiring: https://numerique.canada.ca/rejoindre-notre-equipe/
+"""
+    )

--- a/api/tests/utils/test_crypto.py
+++ b/api/tests/utils/test_crypto.py
@@ -1,0 +1,45 @@
+# pylint: disable=missing-docstring,line-too-long
+from unittest.mock import patch
+from utils import crypto
+
+
+@patch("utils.crypto.requests")
+def test_get_public_key(mock_requests):
+    mock_requests.get.return_value.text = '{"public_keys":[{"key_identifier":"42","key":"some key value"},{"key_identifier":"43","key":"another key value"}]}'
+    assert crypto.get_public_key("42") == "some key value"
+    assert crypto.get_public_key("43") == "another key value"
+    assert crypto.get_public_key("44") is None
+
+
+@patch("utils.crypto.requests")
+def test_get_public_key_no_key(mock_requests):
+    mock_requests.get.return_value.text = '{"public_keys":[]}'
+    assert crypto.get_public_key("42") is None
+
+
+@patch("utils.crypto.get_public_key")
+def test_is_valid_signature(mock_get_public_key):
+    mock_get_public_key.return_value = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsz9ugWDj5jK5ELBK42ynytbo38gP\nHzZFI03Exwz8Lh/tCfL3YxwMdLjB+bMznsanlhK0RwcGP3IDb34kQDIo3Q==\n-----END PUBLIC KEY-----\n"
+    assert (
+        crypto.is_valid_signature(
+            "42",
+            "MEUCIFLZzeK++IhS+y276SRk2Pe5LfDrfvTXu6iwKKcFGCrvAiEAhHN2kDOhy2I6eGkOFmxNkOJ+L2y8oQ9A2T9GGJo6WJY=",
+            '[{"token":"some_token","type":"some_type","url":"some_url","source":"some_source"}]',
+        )
+        is True
+    )
+    assert (
+        crypto.is_valid_signature(
+            "42",
+            "MEUCIFLZzeK++IhS+y276SRk2Pe5LfDrfvTXu6iwKKcFGCrvAiEAhHN2kDOhy2I6eGkOFmxNkOJ+L2y8oQ9A2T9GGJo6WJY=",
+            '[{"token":"nope"}]',
+        )
+        is False
+    )
+
+
+@patch("utils.crypto.get_public_key")
+def test_is_valid_signature_missing_data(mock_get_public_key):
+    mock_get_public_key.return_value = None
+    assert crypto.is_valid_signature("1", "2", "3") is False
+    assert crypto.is_valid_signature(None, None, None) is False

--- a/api/tests/utils/test_helpers.py
+++ b/api/tests/utils/test_helpers.py
@@ -1,45 +1,15 @@
 # pylint: disable=missing-docstring,line-too-long
+import os
+import pytest
+
 from unittest.mock import patch
 from utils import helpers
 
 
-@patch("utils.helpers.requests")
-def test_get_public_key(mock_requests):
-    mock_requests.get.return_value.text = '{"public_keys":[{"key_identifier":"42","key":"some key value"},{"key_identifier":"43","key":"another key value"}]}'
-    assert helpers.get_public_key("42") == "some key value"
-    assert helpers.get_public_key("43") == "another key value"
-    assert helpers.get_public_key("44") is None
+@patch.dict(os.environ, {"MUFFINS": "bananana"}, clear=True)
+def test_get_env_var():
+    assert helpers.get_env_var("MUFFINS") == "bananana"
+    assert helpers.get_env_var("DEFAULT_VALUE", "hello") == "hello"
 
-
-@patch("utils.helpers.requests")
-def test_get_public_key_no_key(mock_requests):
-    mock_requests.get.return_value.text = '{"public_keys":[]}'
-    assert helpers.get_public_key("42") is None
-
-
-@patch("utils.helpers.get_public_key")
-def test_is_valid_signature(mock_get_public_key):
-    mock_get_public_key.return_value = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsz9ugWDj5jK5ELBK42ynytbo38gP\nHzZFI03Exwz8Lh/tCfL3YxwMdLjB+bMznsanlhK0RwcGP3IDb34kQDIo3Q==\n-----END PUBLIC KEY-----\n"
-    assert (
-        helpers.is_valid_signature(
-            "42",
-            "MEUCIFLZzeK++IhS+y276SRk2Pe5LfDrfvTXu6iwKKcFGCrvAiEAhHN2kDOhy2I6eGkOFmxNkOJ+L2y8oQ9A2T9GGJo6WJY=",
-            '[{"token":"some_token","type":"some_type","url":"some_url","source":"some_source"}]',
-        )
-        is True
-    )
-    assert (
-        helpers.is_valid_signature(
-            "42",
-            "MEUCIFLZzeK++IhS+y276SRk2Pe5LfDrfvTXu6iwKKcFGCrvAiEAhHN2kDOhy2I6eGkOFmxNkOJ+L2y8oQ9A2T9GGJo6WJY=",
-            '[{"token":"nope"}]',
-        )
-        is False
-    )
-
-
-@patch("utils.helpers.get_public_key")
-def test_is_valid_signature_missing_data(mock_get_public_key):
-    mock_get_public_key.return_value = None
-    assert helpers.is_valid_signature("1", "2", "3") is False
-    assert helpers.is_valid_signature(None, None, None) is False
+    with pytest.raises(ValueError):
+        helpers.get_env_var("BUELLER")

--- a/api/tests/utils/test_helpers.py
+++ b/api/tests/utils/test_helpers.py
@@ -5,7 +5,7 @@ from utils import helpers
 
 @patch("utils.helpers.requests")
 def test_get_public_key(mock_requests):
-    mock_requests.get.return_value.text = '[{"key_identifier":"42","key":"some key value"},{"key_identifier":"43","key":"another key value"}]'
+    mock_requests.get.return_value.text = '{"public_keys":[{"key_identifier":"42","key":"some key value"},{"key_identifier":"43","key":"another key value"}]}'
     assert helpers.get_public_key("42") == "some key value"
     assert helpers.get_public_key("43") == "another key value"
     assert helpers.get_public_key("44") is None
@@ -13,13 +13,13 @@ def test_get_public_key(mock_requests):
 
 @patch("utils.helpers.requests")
 def test_get_public_key_no_key(mock_requests):
-    mock_requests.get.return_value.text = "[]"
+    mock_requests.get.return_value.text = '{"public_keys":[]}'
     assert helpers.get_public_key("42") is None
 
 
 @patch("utils.helpers.get_public_key")
 def test_is_valid_signature(mock_get_public_key):
-    mock_get_public_key.return_value = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsz9ugWDj5jK5ELBK42ynytbo38gP\nHzZFI03Exwz8Lh/tCfL3YxwMdLjB+bMznsanlhK0RwcGP3IDb34kQDIo3Q==\n-----END PUBLIC KEY-----"
+    mock_get_public_key.return_value = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsz9ugWDj5jK5ELBK42ynytbo38gP\nHzZFI03Exwz8Lh/tCfL3YxwMdLjB+bMznsanlhK0RwcGP3IDb34kQDIo3Q==\n-----END PUBLIC KEY-----\n"
     assert (
         helpers.is_valid_signature(
             "42",

--- a/api/tests/utils/test_helpers.py
+++ b/api/tests/utils/test_helpers.py
@@ -1,15 +1,45 @@
+# pylint: disable=missing-docstring,line-too-long
+from unittest.mock import patch
 from utils import helpers
 
-from unittest.mock import patch
 
-import os
-import pytest
+@patch("utils.helpers.requests")
+def test_get_public_key(mock_requests):
+    mock_requests.get.return_value.text = '[{"key_identifier":"42","key":"some key value"},{"key_identifier":"43","key":"another key value"}]'
+    assert helpers.get_public_key("42") == "some key value"
+    assert helpers.get_public_key("43") == "another key value"
+    assert helpers.get_public_key("44") is None
 
 
-@patch.dict(os.environ, {"MUFFINS": "bananana"}, clear=True)
-def test_get_env_var():
-    assert helpers.get_env_var("MUFFINS") == "bananana"
-    assert helpers.get_env_var("DEFAULT_VALUE", "hello") == "hello"
+@patch("utils.helpers.requests")
+def test_get_public_key_no_key(mock_requests):
+    mock_requests.get.return_value.text = "[]"
+    assert helpers.get_public_key("42") is None
 
-    with pytest.raises(ValueError):
-        helpers.get_env_var("BUELLER")
+
+@patch("utils.helpers.get_public_key")
+def test_is_valid_signature(mock_get_public_key):
+    mock_get_public_key.return_value = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsz9ugWDj5jK5ELBK42ynytbo38gP\nHzZFI03Exwz8Lh/tCfL3YxwMdLjB+bMznsanlhK0RwcGP3IDb34kQDIo3Q==\n-----END PUBLIC KEY-----"
+    assert (
+        helpers.is_valid_signature(
+            "42",
+            "MEUCIFLZzeK++IhS+y276SRk2Pe5LfDrfvTXu6iwKKcFGCrvAiEAhHN2kDOhy2I6eGkOFmxNkOJ+L2y8oQ9A2T9GGJo6WJY=",
+            '[{"token":"some_token","type":"some_type","url":"some_url","source":"some_source"}]',
+        )
+        is True
+    )
+    assert (
+        helpers.is_valid_signature(
+            "42",
+            "MEUCIFLZzeK++IhS+y276SRk2Pe5LfDrfvTXu6iwKKcFGCrvAiEAhHN2kDOhy2I6eGkOFmxNkOJ+L2y8oQ9A2T9GGJo6WJY=",
+            '[{"token":"nope"}]',
+        )
+        is False
+    )
+
+
+@patch("utils.helpers.get_public_key")
+def test_is_valid_signature_missing_data(mock_get_public_key):
+    mock_get_public_key.return_value = None
+    assert helpers.is_valid_signature("1", "2", "3") is False
+    assert helpers.is_valid_signature(None, None, None) is False

--- a/api/utils/crypto.py
+++ b/api/utils/crypto.py
@@ -18,7 +18,7 @@ GITHUB_PUBLIC_KEYS_URL = get_env_var("GITHUB_PUBLIC_KEYS_URL")
 GITHUB_TOKEN = get_env_var("GITHUB_TOKEN")
 
 
-def get_public_key(key_identifier):
+def get_public_key(key_identifier: str) -> str or None:
     "Get public keys from GitHub"
 
     response = requests.get(
@@ -45,7 +45,7 @@ def get_public_key(key_identifier):
     return None
 
 
-def is_valid_signature(key_id, signature, payload):
+def is_valid_signature(key_id: str, signature: str, payload: str) -> bool:
     "Validate the message signature"
 
     if not key_id or not signature or not payload:

--- a/api/utils/crypto.py
+++ b/api/utils/crypto.py
@@ -26,7 +26,7 @@ def get_public_key(key_identifier: str) -> str or None:
         headers={"Authorization": f"token {GITHUB_TOKEN}"},
         timeout=15,
     )
-    public_keys = json.loads(response.text)
+    public_keys = json.loads(response.text, strict=False)
     keys = public_keys.get("public_keys", []) if isinstance(public_keys, dict) else []
 
     if len(keys) == 0:

--- a/api/utils/crypto.py
+++ b/api/utils/crypto.py
@@ -1,0 +1,74 @@
+"""
+Cryptography functions used to validate the GitHub request signature.
+"""
+import base64
+import json
+import requests
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from dotenv import load_dotenv
+from .helpers import get_env_var
+from .logger import logger
+
+load_dotenv()
+
+GITHUB_PUBLIC_KEYS_URL = get_env_var("GITHUB_PUBLIC_KEYS_URL")
+GITHUB_TOKEN = get_env_var("GITHUB_TOKEN")
+
+
+def get_public_key(key_identifier):
+    "Get public keys from GitHub"
+
+    response = requests.get(
+        GITHUB_PUBLIC_KEYS_URL,
+        headers={"Authorization": f"token {GITHUB_TOKEN}"},
+        timeout=15,
+    )
+    public_keys = json.loads(response.text)
+    keys = public_keys.get("public_keys", []) if isinstance(public_keys, dict) else []
+
+    if len(keys) == 0:
+        logger.error("No public keys found in response: %s", response.text)
+        return None
+
+    for key in keys:
+        if key["key_identifier"] == key_identifier:
+            return key["key"]
+
+    logger.error(
+        "Public key not found for key ID '%s'.  Keys returned: %s",
+        key_identifier,
+        public_keys,
+    )
+    return None
+
+
+def is_valid_signature(key_id, signature, payload):
+    "Validate the message signature"
+
+    if not key_id or not signature or not payload:
+        logger.error(
+            "Missing key ID, signature or payload.  Key ID: %s, signature: %s, payload: %s",
+            key_id,
+            signature,
+            payload,
+        )
+        return False
+
+    pem = get_public_key(key_id)
+    if not pem:
+        return False
+
+    public_key = serialization.load_pem_public_key(pem.encode("utf-8"), backend=None)
+    try:
+        public_key.verify(
+            base64.b64decode(signature.encode("utf-8")),
+            payload.encode("utf-8"),
+            ec.ECDSA(hashes.SHA256()),
+        )
+        return True
+    except InvalidSignature:
+        logger.error("Invalid signature for key ID %s: %s", key_id, payload)
+        return False

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -1,79 +1,12 @@
 """
 Helper functions that need a home.
 """
-import base64
-import json
 import os
-import requests
-
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec
-from dotenv import load_dotenv
-from .logger import logger
-
-load_dotenv()
-
-GITHUB_PUBLIC_KEYS_URL = os.getenv("GITHUB_PUBLIC_KEYS_URL", "")
-GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "")
-
-if GITHUB_PUBLIC_KEYS_URL.strip() == "":
-    raise ValueError("GITHUB_PUBLIC_KEYS_URL cannot be empty")
-if GITHUB_TOKEN.strip() == "":
-    raise ValueError("GITHUB_TOKEN cannot be empty")
 
 
-def get_public_key(key_identifier):
-    "Get public keys from GitHub"
-
-    response = requests.get(
-        GITHUB_PUBLIC_KEYS_URL,
-        headers={"Authorization": f"token {GITHUB_TOKEN}"},
-        timeout=15,
-    )
-    public_keys = json.loads(response.text)
-    keys = public_keys.get("public_keys", [])
-
-    if len(keys) == 0:
-        logger.error("No public keys found: %s", public_keys)
-        return None
-
-    for key in keys:
-        if key["key_identifier"] == key_identifier:
-            return key["key"]
-
-    logger.error(
-        "Public key not found for key ID '%s'.  Keys returned: %s",
-        key_identifier,
-        public_keys,
-    )
-    return None
-
-
-def is_valid_signature(key_id, signature, payload):
-    "Validate the message signature"
-
-    if not key_id or not signature or not payload:
-        logger.error(
-            "Missing key ID, signature or payload.  Key ID: %s, signature: %s, payload: %s",
-            key_id,
-            signature,
-            payload,
-        )
-        return False
-
-    pem = get_public_key(key_id)
-    if not pem:
-        return False
-
-    public_key = serialization.load_pem_public_key(pem.encode("utf-8"), backend=None)
-    try:
-        public_key.verify(
-            base64.b64decode(signature.encode("utf-8")),
-            payload.encode("utf-8"),
-            ec.ECDSA(hashes.SHA256()),
-        )
-        return True
-    except InvalidSignature:
-        logger.error("Invalid signature for key ID %s: %s", key_id, payload)
-        return False
+def get_env_var(env_var_name: str, default_value: str = "") -> str:
+    "Get environment variable value and fail if it does not exist."
+    value = os.environ.get(env_var_name, default_value)
+    if value.strip() == "":
+        raise ValueError(f"{env_var_name} environment variable is empty")
+    return value

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -32,14 +32,15 @@ def get_public_key(key_identifier):
         timeout=15,
     )
     public_keys = json.loads(response.text)
+    keys = public_keys.get("public_keys", [])
 
-    if not isinstance(public_keys, list) or len(public_keys) == 0:
+    if len(keys) == 0:
         logger.error("No public keys found: %s", public_keys)
         return None
 
-    for public_key in public_keys:
-        if public_key["key_identifier"] == key_identifier:
-            return public_key["key"]
+    for key in keys:
+        if key["key_identifier"] == key_identifier:
+            return key["key"]
 
     logger.error(
         "Public key not found for key ID '%s'.  Keys returned: %s",

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -1,12 +1,78 @@
 """
 Helper functions that need a home.
 """
-from os import environ
+import base64
+import json
+import os
+import requests
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from dotenv import load_dotenv
+from .logger import logger
+
+load_dotenv()
+
+GITHUB_PUBLIC_KEYS_URL = os.getenv("GITHUB_PUBLIC_KEYS_URL", "")
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "")
+
+if GITHUB_PUBLIC_KEYS_URL.strip() == "":
+    raise ValueError("GITHUB_PUBLIC_KEYS_URL cannot be empty")
+if GITHUB_TOKEN.strip() == "":
+    raise ValueError("GITHUB_TOKEN cannot be empty")
 
 
-def get_env_var(env_var_name: str, default_value: str = "") -> str:
-    "Get environment variable value and fail if it does not exist."
-    value = environ.get(env_var_name, default_value)
-    if value.strip() == "":
-        raise ValueError(f"{env_var_name} environment variable is empty")
-    return value
+def get_public_key(key_identifier):
+    "Get public keys from GitHub"
+
+    response = requests.get(
+        GITHUB_PUBLIC_KEYS_URL,
+        headers={"Authorization": f"token {GITHUB_TOKEN}"},
+        timeout=15,
+    )
+    public_keys = json.loads(response.text)
+
+    if not isinstance(public_keys, list) or len(public_keys) == 0:
+        logger.error("No public keys found: %s", public_keys)
+        return None
+
+    for public_key in public_keys:
+        if public_key["key_identifier"] == key_identifier:
+            return public_key["key"]
+
+    logger.error(
+        "Public key not found for key ID '%s'.  Keys returned: %s",
+        key_identifier,
+        public_keys,
+    )
+    return None
+
+
+def is_valid_signature(key_id, signature, payload):
+    "Validate the message signature"
+
+    if not key_id or not signature or not payload:
+        logger.error(
+            "Missing key ID, signature or payload.  Key ID: %s, signature: %s, payload: %s",
+            key_id,
+            signature,
+            payload,
+        )
+        return False
+
+    pem = get_public_key(key_id)
+    if not pem:
+        return False
+
+    public_key = serialization.load_pem_public_key(pem.encode("utf-8"), backend=None)
+    try:
+        public_key.verify(
+            base64.b64decode(signature.encode("utf-8")),
+            payload.encode("utf-8"),
+            ec.ECDSA(hashes.SHA256()),
+        )
+        return True
+    except InvalidSignature:
+        logger.error("Invalid signature for key ID %s: %s", key_id, payload)
+        return False

--- a/api/utils/logger.py
+++ b/api/utils/logger.py
@@ -11,4 +11,4 @@ logging.basicConfig(
     level=LOG_LEVEL,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("api")

--- a/api/utils/logger.py
+++ b/api/utils/logger.py
@@ -4,10 +4,10 @@ Logging configuration
 import logging
 import os
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG")
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 
 logging.basicConfig(
-    format='{"time":"%(asctime)s","name":"%(name)s","level":"%(levelname)s","message":"%(message)s"}',  # pylint: disable=line-too-long
+    format='{"time":"%(asctime)s","level":"%(levelname)s","message":"%(message)s"}',
     level=LOG_LEVEL,
 )
 

--- a/api/utils/logger.py
+++ b/api/utils/logger.py
@@ -7,7 +7,7 @@ import os
 LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG")
 
 logging.basicConfig(
-    format="{'time':'%(asctime)s','name':'%(name)s','level':'%(levelname)s','message':'%(message)s'}",  # pylint: disable=line-too-long
+    format='{"time":"%(asctime)s","name":"%(name)s","level":"%(levelname)s","message":"%(message)s"}',  # pylint: disable=line-too-long
     level=LOG_LEVEL,
 )
 

--- a/api/utils/logger.py
+++ b/api/utils/logger.py
@@ -1,0 +1,14 @@
+"""
+Logging configuration
+"""
+import logging
+import os
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG")
+
+logging.basicConfig(
+    format="{'time':'%(asctime)s','name':'%(name)s','level':'%(levelname)s','message':'%(message)s'}",  # pylint: disable=line-too-long
+    level=LOG_LEVEL,
+)
+
+logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Summary
Add validation to check that the GitHub secret scanning alert is signed by a valid GitHub private key.

Also fixes pylint import errors reported in the devcontainer.

# Related
- Closes #5