### PR TITLE
feat: Terraform for the API's Lambda function

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -12,6 +12,7 @@ env:
   TERRAFORM_VERSION: 1.3.8
   TERRAGRUNT_VERSION: 0.43.2
   AWS_REGION: ca-central-1
+  TF_VAR_github_token: ${{ secrets.API_GITHUB_TOKEN }}
 
 permissions:
   id-token: write
@@ -40,3 +41,7 @@ jobs:
       - name: Apply hosted_zone
         working-directory: terragrunt/env/production/hosted_zone
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply api
+        working-directory: terragrunt/env/production/api
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve            

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -12,6 +12,7 @@ env:
   TERRAFORM_VERSION: 1.3.8
   TERRAGRUNT_VERSION: 0.43.2
   AWS_REGION: ca-central-1
+  TF_VAR_github_token: ${{ secrets.API_GITHUB_TOKEN }}
 
 permissions:
   id-token: write
@@ -26,7 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
+        include:          
+          - module: api
           - module: hosted_zone
 
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Github secret scanning alert service :microscope: :warning:
 
-This repo holds the service and infrastructure code for the [Github secret scanning alert service](https://docs.github.com/en/developers/overview/secret-scanning-partner-program#create-a-secret-alert-service).
+This repo holds the API and infrastructure code for the [Github secret scanning alert service](https://docs.github.com/en/developers/overview/secret-scanning-partner-program#create-a-secret-alert-service).
+
+When GitHub detects our registered secrets in public repositories, it will send an alert to this service.  The detected secret will be logged and an alarm triggered so the impacted team can take action.
+
+## Local development
+1. Start the [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers).
+1. Make a copy of `api/.env.example` and name it `api/.env`.
+1. Run `cd api && make dev` and access on `localhost:8000`.

--- a/terragrunt/aws/api/ecr.tf
+++ b/terragrunt/aws/api/ecr.tf
@@ -1,0 +1,47 @@
+resource "aws_ecr_repository" "api" {
+  name                 = "${var.product_name}/api"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "scan_files_exire_untagged" {
+  repository = aws_ecr_repository.api.name
+  policy = jsonencode({
+    "rules" : [
+      {
+        "rulePriority" : 1,
+        "description" : "Expire untagged images older than 14 days",
+        "selection" : {
+          "tagStatus" : "untagged",
+          "countType" : "sinceImagePushed",
+          "countUnit" : "days",
+          "countNumber" : 14
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      },
+      {
+        "rulePriority" : 2,
+        "description" : "Keep last 20 tagged images",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "tagPrefixList" : ["latest"],
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 20
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -1,0 +1,11 @@
+data "aws_iam_policy_document" "api_policies" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameters",
+    ]
+    resources = [
+      aws_ssm_parameter.github_token.arn
+    ]
+  }
+}

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -1,0 +1,5 @@
+variable "github_token" {
+  description = "The GitHub token used to retrieve the public key used to verify the alert signature."
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -1,0 +1,26 @@
+module "api" {
+  source    = "github.com/cds-snc/terraform-modules?ref=v5.0.0//lambda"
+  name      = "${var.product_name}-api"
+  ecr_arn   = aws_ecr_repository.api.arn
+  image_uri = "${aws_ecr_repository.api.repository_url}:latest"
+
+  memory                 = 1024
+  timeout                = 120
+  enable_lambda_insights = true
+
+  environment_variables = {
+    GITHUB_PUBLIC_KEYS_URL = "https://api.github.com/meta/public_keys/secret_scanning"
+    LOG_LEVEL              = "WARNING"
+  }
+
+  policies = [
+    data.aws_iam_policy_document.api_policies.json,
+  ]
+
+  billing_tag_value = var.billing_code
+}
+
+resource "aws_lambda_function_url" "api" {
+  function_name      = module.api.function_name
+  authorization_type = "NONE"
+}

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -1,0 +1,9 @@
+output "function_name" {
+  description = "The name of the Lambda function"
+  value       = module.api.function_name
+}
+
+output "function_url" {
+  description = "The URL of the Lambda function"
+  value       = aws_lambda_function_url.api.function_url
+}

--- a/terragrunt/aws/api/secrets.tf
+++ b/terragrunt/aws/api/secrets.tf
@@ -1,0 +1,10 @@
+resource "aws_ssm_parameter" "github_token" {
+  name  = "${var.product_name}-github-token"
+  type  = "SecureString"
+  value = var.github_token
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}

--- a/terragrunt/env/production/api/terragrunt.hcl
+++ b/terragrunt/env/production/api/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../aws//api"
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
## Summary
Add the Terraform and Terragrunt to create the API's Lambda
function and ECR.

## Related
- cds-snc/site-reliability-engineering#812
- cds-snc/notification-planning#838