### PR TITLE
fix: update to use an API `.env`

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -12,7 +12,7 @@ env:
   TERRAFORM_VERSION: 1.3.8
   TERRAGRUNT_VERSION: 0.43.2
   AWS_REGION: ca-central-1
-  TF_VAR_github_token: ${{ secrets.API_GITHUB_TOKEN }}
+  TF_VAR_api_config: ${{ secrets.API_CONFIG }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -12,7 +12,7 @@ env:
   TERRAFORM_VERSION: 1.3.8
   TERRAGRUNT_VERSION: 0.43.2
   AWS_REGION: ca-central-1
-  TF_VAR_github_token: ${{ secrets.API_GITHUB_TOKEN }}
+  TF_VAR_api_config: ${{ secrets.API_CONFIG }}
 
 permissions:
   id-token: write

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "api_policies" {
       "ssm:GetParameters",
     ]
     resources = [
-      aws_ssm_parameter.github_token.arn
+      aws_ssm_parameter.api_config.arn
     ]
   }
 }

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -1,5 +1,5 @@
-variable "github_token" {
-  description = "The GitHub token used to retrieve the public key used to verify the alert signature."
+variable "api_config" {
+  description = "The API environment variables that are written to a .env read by the Lambda function."
   type        = string
   sensitive   = true
 }

--- a/terragrunt/aws/api/secrets.tf
+++ b/terragrunt/aws/api/secrets.tf
@@ -1,7 +1,7 @@
 resource "aws_ssm_parameter" "api_config" {
   name  = "${var.product_name}-config"
   type  = "SecureString"
-  value = var.github_token
+  value = var.api_config
 
   tags = {
     CostCentre = var.billing_code

--- a/terragrunt/aws/api/secrets.tf
+++ b/terragrunt/aws/api/secrets.tf
@@ -1,5 +1,5 @@
-resource "aws_ssm_parameter" "github_token" {
-  name  = "${var.product_name}-github-token"
+resource "aws_ssm_parameter" "api_config" {
+  name  = "${var.product_name}-config"
   type  = "SecureString"
   value = var.github_token
 


### PR DESCRIPTION
## Summary
Add a `github-secret-scanning-config` that writes a `.env` on Lambda startup.  We can use this to set all the API's private env vars.

## Related
- cds-snc/site-reliability-engineering#812
- cds-snc/notification-planning#838