### PR TITLE
feat: API Lambda handler

### DIFF
--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -1,7 +1,51 @@
 #!/bin/sh
-#!/bin/sh
+# shellcheck disable=SC2120
+
+ENV_PATH="/tmp/github-secret-scanning"
+TMP_ENV_FILE="$ENV_PATH/.env"
+
+# Check if a variable exists in the execution environment and is not empty
+var_expand() {
+  if [ -z "${1-}" ] || [ $# -ne 1 ]; then
+    printf 'var_expand: expected one argument\n' >&2;
+    return 1;
+  fi
+  eval printf '%s' "\"\${$1?}\"" 2> /dev/null # Variable double substitution to be able to check for variable
+}
+
+# Export variables from a .env file into the current execution environment
+load_non_existing_envs() {
+  _isComment='^[[:space:]]*#'
+  _isBlank='^[[:space:]]*$'
+  while IFS= read -r line; do
+    if echo "$line" | grep -Eq "$_isComment"; then # Ignore comment line
+      continue
+    fi
+    if echo "$line" | grep -Eq "$_isBlank"; then # Ignore blank line
+      continue
+    fi
+    key=$(echo "$line" | cut -d '=' -f 1)
+    value=$(echo "$line" | cut -d '=' -f 2-)
+
+    if [ -z "$(var_expand "$key")" ]; then # Check if environment variable doesn't exist
+      export "${key}=${value}"
+    fi
+  done < $TMP_ENV_FILE
+}
+
 echo "Retrieving environment parameters"
-aws ssm get-parameters --region ca-central-1 --with-decryption --names github-secret-scanning-config --query 'Parameters[*].Value' --output text > ".env"
+if [ ! -f "$ENV_PATH/.env" ]; then
+    if [ ! -d "$ENV_PATH" ]; then
+        mkdir "$ENV_PATH"
+    fi
+    aws ssm get-parameters \
+        --region ca-central-1 \
+        --with-decryption \
+        --names github-secret-scanning-config \
+        --query 'Parameters[*].Value' \
+        --output text > "$TMP_ENV_FILE"
+fi
+load_non_existing_envs
 
 echo "Starting lambda handler"
 exec /usr/local/bin/python -m awslambdaric "$1"

--- a/api/main.py
+++ b/api/main.py
@@ -2,6 +2,7 @@
 Main API entrypoint
 """
 from fastapi import FastAPI
+from mangum import Mangum
 from routers import alerts, ops
 
 
@@ -13,3 +14,5 @@ app = FastAPI(
 
 app.include_router(alerts.router)
 app.include_router(ops.router)
+
+handler = Mangum(app)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,5 @@
 cryptography==39.0.1
 fastapi==0.91.0
+mangum==0.17.0
 python-dotenv==0.21.1
 requests==2.28.2


### PR DESCRIPTION
## Summary
Add the API's Lambda event handler using the Mangum ASGI adapter module.

Fix how the Lambda's environment variables are loaded from SSM ParameterStore since only the `/tmp` directory is writable.  This will load all values from the `github-secret-scanning-config` into a temp `.env` file and then export them to the execution environment if they haven't already been set.

## Related
- cds-snc/site-reliability-engineering#812
- cds-snc/notification-planning#838