### PR TITLE
feat: custom API URL using CloudFront distribution

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -44,4 +44,8 @@ jobs:
 
       - name: Apply api
         working-directory: terragrunt/env/production/api
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve            
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply cloudfront
+        working-directory: terragrunt/env/production/cloudfront
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         include:          
           - module: api
+          - module: cloudfront
           - module: hosted_zone
 
     runs-on: ubuntu-latest

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -5,4 +5,3 @@ skip-check:
   - CKV_AWS_136 # ECR: default encryption key is acceptable
   - CKV_AWS_158 # CloudWatch: default encryption key is acceptable
   - CKV_AWS_192 # CloudFront: false-positive, AWSManagedRulesKnownBadInputsRuleSet is being applied
-  - CKV2_AWS_32 # CloudFront: false-positive, strict security header policy is being applied

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -1,5 +1,8 @@
 skip-check:
   - CKV_AWS_51 # ECR: `latest` tag is used for development
+  - CKV_AWS_86 # CloudFront: access logging not required
   - CKV_AWS_117 # Lambda: access to VPC resources not required
   - CKV_AWS_136 # ECR: default encryption key is acceptable
   - CKV_AWS_158 # CloudWatch: default encryption key is acceptable
+  - CKV_AWS_192 # CloudFront: false-positive, AWSManagedRulesKnownBadInputsRuleSet is being applied
+  - CKV2_AWS_32 # CloudFront: false-positive, strict security header policy is being applied

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -5,3 +5,4 @@ skip-check:
   - CKV_AWS_136 # ECR: default encryption key is acceptable
   - CKV_AWS_158 # CloudWatch: default encryption key is acceptable
   - CKV_AWS_192 # CloudFront: false-positive, AWSManagedRulesKnownBadInputsRuleSet is being applied
+  - CKV2_AWS_32 # CloudFront: false-positive, strict header security policy is being applied

--- a/terragrunt/aws/cloudfront/certificate.tf
+++ b/terragrunt/aws/cloudfront/certificate.tf
@@ -1,0 +1,41 @@
+resource "aws_acm_certificate" "api" {
+  provider = aws.us-east-1
+
+  domain_name               = var.domain
+  subject_alternative_names = ["*.${var.domain}"]
+  validation_method         = "DNS"
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "api_cert_validation" {
+  zone_id = var.hosted_zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.api.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "api" {
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.api.arn
+  validation_record_fqdns = [for record in aws_route53_record.api_cert_validation : record.fqdn]
+}

--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -37,7 +37,7 @@ resource "aws_cloudfront_distribution" "api" {
 
     target_origin_id           = var.api_function_name
     viewer_protocol_policy     = "redirect-to-https"
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_api.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_api.id
     cache_policy_id            = data.aws_cloudfront_cache_policy.managed_caching_optimized.id
     origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.managed_all_viewer.id
   }
@@ -50,7 +50,7 @@ resource "aws_cloudfront_distribution" "api" {
 
     target_origin_id           = var.api_function_name
     viewer_protocol_policy     = "redirect-to-https"
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_api.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_api.id
     cache_policy_id            = data.aws_cloudfront_cache_policy.managed_caching_disabled.id
     origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.managed_all_viewer.id
   }
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "api" {
   }
 }
 
-resource "aws_cloudfront_response_headers_policy" "api" {
+resource "aws_cloudfront_response_headers_policy" "security_headers_api" {
   name = "api-cloudfront-headers"
 
   security_headers_config {

--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -1,0 +1,107 @@
+data "aws_cloudfront_cache_policy" "managed_caching_optimized" {
+  name = "Managed-CachingOptimized"
+}
+
+data "aws_cloudfront_cache_policy" "managed_caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+data "aws_cloudfront_origin_request_policy" "managed_all_viewer" {
+  name = "Managed-AllViewer"
+}
+
+resource "aws_cloudfront_distribution" "api" {
+  enabled     = true
+  aliases     = [var.domain]
+  price_class = "PriceClass_100"
+  web_acl_id  = aws_wafv2_web_acl.api.arn
+
+  origin {
+    domain_name = split("/", var.api_function_url)[2]
+    origin_id   = var.api_function_name
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_read_timeout    = 60
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  # Optimized caching for all GET/HEAD requests
+  default_cache_behavior {
+    allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods  = ["GET", "HEAD"]
+
+
+    target_origin_id           = var.api_function_name
+    viewer_protocol_policy     = "redirect-to-https"
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_api.id
+    cache_policy_id            = data.aws_cloudfront_cache_policy.managed_caching_optimized.id
+    origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.managed_all_viewer.id
+  }
+
+  # Prevent caching of healthcheck calls
+  ordered_cache_behavior {
+    path_pattern    = "/healthcheck"
+    allowed_methods = ["GET", "HEAD"]
+    cached_methods  = ["GET", "HEAD"]
+
+    target_origin_id           = var.api_function_name
+    viewer_protocol_policy     = "redirect-to-https"
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_api.id
+    cache_policy_id            = data.aws_cloudfront_cache_policy.managed_caching_disabled.id
+    origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.managed_all_viewer.id
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.api.certificate_arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
+  }
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_cloudfront_response_headers_policy" "api" {
+  name = "api-cloudfront-headers"
+
+  security_headers_config {
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+    content_type_options {
+      override = true
+    }
+    content_security_policy {
+      content_security_policy = "report-uri https://csp-report-to.security.cdssandbox.xyz/report; default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; frame-ancestors 'self'; form-action 'self';"
+      override                = false
+    }
+    referrer_policy {
+      override        = true
+      referrer_policy = "same-origin"
+    }
+    strict_transport_security {
+      override                   = true
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      preload                    = true
+    }
+    xss_protection {
+      override   = true
+      mode_block = true
+      protection = true
+    }
+  }
+}

--- a/terragrunt/aws/cloudfront/iam.tf
+++ b/terragrunt/aws/cloudfront/iam.tf
@@ -1,0 +1,65 @@
+resource "aws_iam_role" "waf_log_role" {
+  name               = "${var.product_name}-waf-logs"
+  assume_role_policy = data.aws_iam_policy_document.firehose_assume_role.json
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_iam_policy" "write_waf_logs" {
+  name        = "${var.product_name}-waf-logs"
+  description = "Allow Firehose to write WAF logs to S3"
+  policy      = data.aws_iam_policy_document.write_waf_logs.json
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "write_waf_logs" {
+  role       = aws_iam_role.waf_log_role.name
+  policy_arn = aws_iam_policy.write_waf_logs.arn
+}
+
+data "aws_iam_policy_document" "firehose_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "write_waf_logs" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      local.cbs_satellite_bucket_arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject*",
+      "s3:PutObject*",
+    ]
+
+    resources = [
+      "${local.cbs_satellite_bucket_arn}/waf_acl_logs/*"
+    ]
+  }
+}

--- a/terragrunt/aws/cloudfront/inputs.tf
+++ b/terragrunt/aws/cloudfront/inputs.tf
@@ -1,0 +1,21 @@
+variable "api_function_name" {
+  description = "The name of the API lambda function"
+  type        = string
+}
+
+variable "api_function_url" {
+  description = "The URL of the API lambda function"
+  type        = string
+}
+
+variable "enable_waf" {
+  description = "(Optional) Should the WAF be enabled? Defaults to true."
+  type        = bool
+  default     = true
+}
+
+variable "hosted_zone_id" {
+  description = "The hosted zone ID to create DNS records in"
+  type        = string
+}
+

--- a/terragrunt/aws/cloudfront/locals.tf
+++ b/terragrunt/aws/cloudfront/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  cbs_satellite_bucket_arn = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
+}

--- a/terragrunt/aws/cloudfront/route53.tf
+++ b/terragrunt/aws/cloudfront/route53.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_record" "api_A" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.api.domain_name
+    zone_id                = aws_cloudfront_distribution.api.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_health_check" "api" {
+  fqdn              = aws_route53_record.api_A.fqdn
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/healthcheck"
+  failure_threshold = "5"
+  request_interval  = "30"
+  regions           = ["us-east-1", "us-west-1", "us-west-2"]
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -1,0 +1,283 @@
+resource "aws_wafv2_web_acl" "api" {
+  provider = aws.us-east-1
+
+  name        = var.product_name
+  description = "WAF for GitHub secret alert API"
+  scope       = "CLOUDFRONT"
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "APIInvalidPath"
+    priority = 1
+
+    action {
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
+    }
+
+    statement {
+      not_statement {
+        statement {
+          regex_pattern_set_reference_statement {
+            arn = aws_wafv2_regex_pattern_set.valid_uri_paths.arn
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "APIInvalidPaths"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 10
+
+    override_action {
+      dynamic "none" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "APIRateLimit"
+    priority = 20
+
+    action {
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 2000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "APIRateLimit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 30
+
+    override_action {
+      dynamic "none" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 40
+
+    override_action {
+      dynamic "none" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesLinuxRuleSet"
+    priority = 50
+
+    override_action {
+      dynamic "none" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesLinuxRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesLinuxRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "api"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
+  provider    = aws.us-east-1
+  name        = "valid-api-paths"
+  description = "Regex to match the API's valid paths"
+  scope       = "CLOUDFRONT"
+
+  # ops
+  regular_expression {
+    regex_string = "^/(healthcheck|version|docs|openapi.json|\\.well-known\\/security\\.txt)$"
+  }
+
+  # alerts
+  regular_expression {
+    regex_string = "^/alert$"
+  }
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "api" {
+  provider = aws.us-east-1
+
+  name        = "aws-waf-logs-${var.product_name}"
+  destination = "extended_s3"
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  extended_s3_configuration {
+    role_arn           = aws_iam_role.waf_log_role.arn
+    prefix             = "waf_acl_logs/AWSLogs/${var.account_id}/"
+    bucket_arn         = local.cbs_satellite_bucket_arn
+    compression_format = "GZIP"
+
+    cloudwatch_logging_options {
+      enabled = false
+    }
+  }
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "api" {
+  provider                = aws.us-east-1
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.api.arn]
+  resource_arn            = aws_wafv2_web_acl.api.arn
+}

--- a/terragrunt/env/production/cloudfront/terragrunt.hcl
+++ b/terragrunt/env/production/cloudfront/terragrunt.hcl
@@ -1,0 +1,38 @@
+terraform {
+  source = "../../../aws//cloudfront"
+}
+
+dependencies {
+  paths = ["../hosted_zone", "../api"]
+}
+
+dependency "hosted_zone" {
+  config_path = "../hosted_zone"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    hosted_zone_id = "1234567890"
+  }
+}
+
+dependency "api" {
+  config_path = "../api"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    api_function_name = "github-secret-scanning-api"
+    api_function_url  = "https://api.github-secret-scanning.com"
+  }
+}
+
+inputs = {
+  api_function_name = dependency.api.outputs.function_name
+  api_function_url  = dependency.api.outputs.function_url
+  hosted_zone_id    = dependency.hosted_zone.outputs.hosted_zone_id
+}  
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
## Summary
Add a CloudFront distribution to provide a custom URL and caching to the Lambda API.

Also add a WAF ACL to filter malicious traffic.

## Related
- cds-snc/site-reliability-engineering#812
- cds-snc/notification-planning#838