### PR TITLE
feat: send API logs to Sentinel

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -13,6 +13,8 @@ env:
   TERRAGRUNT_VERSION: 0.43.2
   AWS_REGION: ca-central-1
   TF_VAR_api_config: ${{ secrets.API_CONFIG }}
+  TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+  TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -13,6 +13,8 @@ env:
   TERRAGRUNT_VERSION: 0.43.2
   AWS_REGION: ca-central-1
   TF_VAR_api_config: ${{ secrets.API_CONFIG }}
+  TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+  TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 
 permissions:
   id-token: write

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -3,3 +3,15 @@ variable "api_config" {
   type        = string
   sensitive   = true
 }
+
+variable "log_analytics_workspace_id" {
+  description = "The Sentinel workspace ID. Used by the Sentinel Forwarder to send the API logs to Sentinel."
+  type        = string
+  sensitive   = true
+}
+
+variable "log_analytics_workspace_key" {
+  description = "The Sentinel workspace authentication key. Used by the Sentinel Forwarder to send the API logs to Sentinel."
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/aws/api/sentinel.tf
+++ b/terragrunt/aws/api/sentinel.tf
@@ -3,6 +3,8 @@ module "sentinel_forwarder" {
   function_name     = var.product_name
   billing_tag_value = var.billing_code
 
+  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:42"
+
   customer_id = var.log_analytics_workspace_id
   shared_key  = var.log_analytics_workspace_key
 

--- a/terragrunt/aws/api/sentinel.tf
+++ b/terragrunt/aws/api/sentinel.tf
@@ -1,0 +1,12 @@
+module "sentinel_forwarder" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v5.0.1//sentinel_forwarder"
+  function_name     = "${var.product_name}-sentinel-forwarder"
+  billing_tag_value = var.billing_code
+
+  customer_id = var.log_analytics_workspace_id
+  shared_key  = var.log_analytics_workspace_key
+
+  cloudwatch_log_arns = [
+    "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/${module.api.function_name}"
+  ]
+}

--- a/terragrunt/aws/api/sentinel.tf
+++ b/terragrunt/aws/api/sentinel.tf
@@ -1,6 +1,6 @@
 module "sentinel_forwarder" {
   source            = "github.com/cds-snc/terraform-modules?ref=v5.0.1//sentinel_forwarder"
-  function_name     = "${var.product_name}-sentinel-forwarder"
+  function_name     = var.product_name
   billing_tag_value = var.billing_code
 
   customer_id = var.log_analytics_workspace_id

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -235,7 +235,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
 
   # ops
   regular_expression {
-    regex_string = "^/(healthcheck|version|docs|openapi.json|\\.well-known\\/security\\.txt)$"
+    regex_string = "^/(healthcheck|version|docs|openapi.json|.well-known/security.txt)$"
   }
 
   # alerts


### PR DESCRIPTION
## Summary
Add the Sentinel Forwarder module to send the API's logs to Sentinel for analysis.  Detected secrets are logged with a consistent string pattern as JSON so these can be alerted on.

## Related
- Closes #6 
- cds-snc/site-reliability-engineering#812
- cds-snc/notification-planning#838