### PR TITLE
feat: API alarms module

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -15,6 +15,7 @@ env:
   TF_VAR_api_config: ${{ secrets.API_CONFIG }}
   TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+  TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 permissions:
   id-token: write
@@ -50,4 +51,8 @@ jobs:
 
       - name: Apply cloudfront
         working-directory: terragrunt/env/production/cloudfront
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply alarms
+        working-directory: terragrunt/env/production/alarms
         run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -15,6 +15,7 @@ env:
   TF_VAR_api_config: ${{ secrets.API_CONFIG }}
   TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+  TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 permissions:
   id-token: write
@@ -29,7 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:          
+        include:
+          - module: alarms
           - module: api
           - module: cloudfront
           - module: hosted_zone

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -1,0 +1,57 @@
+resource "aws_cloudwatch_log_metric_filter" "api_error" {
+  name           = local.error_logged_api
+  pattern        = "?ERROR ?Error ?error ?failed"
+  log_group_name = local.api_cloudwatch_log_group
+
+  metric_transformation {
+    name      = local.error_logged_api
+    namespace = local.metric_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_error" {
+  alarm_name          = local.error_logged_api
+  alarm_description   = "Errors logged by the API lambda function"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  metric_name        = aws_cloudwatch_log_metric_filter.api_error.metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.api_error.metric_transformation[0].namespace
+  period             = "60"
+  evaluation_periods = "1"
+  statistic          = "Sum"
+  threshold          = "1"
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [local.sns_topic_arn]
+  ok_actions    = [local.sns_topic_arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "api_secret_detected" {
+  name           = local.secret_detected_api
+  pattern        = "Secret detected"
+  log_group_name = local.api_cloudwatch_log_group
+
+  metric_transformation {
+    name      = local.secret_detected_api
+    namespace = local.metric_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_secret_detected" {
+  alarm_name          = local.secret_detected_api
+  alarm_description   = "GitHub alert that a secret has been detected"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  metric_name        = aws_cloudwatch_log_metric_filter.api_secret_detected.metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.api_secret_detected.metric_transformation[0].namespace
+  period             = "60"
+  evaluation_periods = "1"
+  statistic          = "Sum"
+  threshold          = "1"
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [local.sns_topic_arn]
+  ok_actions    = [local.sns_topic_arn]
+}

--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -1,0 +1,10 @@
+variable "api_function_name" {
+  description = "The name of the API function."
+  type        = string
+}
+
+variable "slack_webhook_url" {
+  description = "The URL of the Slack webhook."
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  api_cloudwatch_log_group = "/aws/lambda/${var.api_function_name}"
+  error_logged_api         = "ErrorLoggedAPI"
+  metric_namespace         = "GitHubSecretScanning"
+  secret_detected_api      = "SecretDetectedAPI"
+  sns_topic_arn            = "arn:aws:sns:${var.region}:${var.account_id}:internal-sre-alert"
+}

--- a/terragrunt/aws/alarms/slack.tf
+++ b/terragrunt/aws/alarms/slack.tf
@@ -1,0 +1,12 @@
+module "cloudwatch_alarms_slack" {
+  source = "github.com/cds-snc/terraform-modules?ref=v5.0.2//notify_slack"
+
+  function_name     = var.product_name
+  project_name      = var.product_name
+  slack_webhook_url = var.slack_webhook_url
+  sns_topic_arns = [
+    local.sns_topic_arn,
+  ]
+
+  billing_tag_value = var.billing_code
+}

--- a/terragrunt/env/production/alarms/.terraform.lock.hcl
+++ b/terragrunt/env/production/alarms/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.3.0"
+  hashes = [
+    "h1:OmE1tPjiST8iQp6fC0N3Xzur+q2RvgvD7Lz0TpKSRBw=",
+    "zh:0869128d13abe12b297b0cd13b8767f10d6bf047f5afc4215615aabc39c2eb4f",
+    "zh:481ed837d63ba3aa45dd8736da83e911e3509dee0e7961bf5c00ed2644f807b3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9f08fe2977e2166849be24fb9f394e4d2697414d463f7996fd0d7beb4e19a29c",
+    "zh:9fe566deeafd460d27999ca0bbfd85426a5fcfcb40007b23884deb76da127b6f",
+    "zh:a1bd9a60925d9769e0da322e4523330ee86af9dc2e770cba1d0247a999ef29cb",
+    "zh:bb4094c8149f74308b22a87e1ac19bcccca76e8ef021b571074d9bccf1c0c6f0",
+    "zh:c8984c9def239041ce41ec8e19bbd76a49e74ed2024ff736dad60429dee89bcc",
+    "zh:ea4bb5ae73db1de3a586e62f39106f5e56770804a55aa5e6b4f642df973e0e75",
+    "zh:f44a9d596ecc3a8c5653f56ba0cd202ad93b49f76767f4608daf7260b813289e",
+    "zh:f5c5e6cc9f7f070020ab7d95fcc9ed8e20d5cf219978295a71236e22cbb6d508",
+    "zh:fd2273f51dcc8f43403bf1e425ba9db08a57c3ddcba5ad7a51742ccde21ca611",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.54.0"
+  constraints = "~> 4.52"
+  hashes = [
+    "h1:j/L01+hlHVM2X2VrkQC2WtMZyu4ZLhDMw+HDJ7k0Y2Q=",
+    "zh:24358aefc06b3f38878680fe606dab2570cb58ab952750c47e90b81d3b05e606",
+    "zh:3fc0ef459d6bb4fbb0e4eb7b8adadddd636efa6d975be6e70de7327d83e15729",
+    "zh:67e765119726f47b1916316ac95c3cd32ac074b454f2a67b6127120b476bc483",
+    "zh:71aed1300debac24f11263a6f8a231c6432497b25e623e8f34e27121af65f523",
+    "zh:722043077e63713d4e458f3228be30c21fcff5b6660c6de8b96967337cdc604a",
+    "zh:76d67be4220b93cfaca0882f46db9a42b4ca48285a64fe304f108dde85f4d611",
+    "zh:81534c18d9f02648b1644a7937e7bea56e91caef13b41de121ee51168faad680",
+    "zh:89983ab2596846d5f3413ff1b5b9b21424c3c757a54dcc5a4604d3ac34fea1a6",
+    "zh:8a603ac6884de5dc51c372f641f9613aefd87059ff6e6a74b671f6864226e06f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b6fae6c1cda6d842406066dac7803d24a597b62da5fae33bcd50c5dae70140c2",
+    "zh:bc4c3b4bfb715beecf5186dfeb91173ef1a9c0b68e8c45cbeee180195bbfa37f",
+    "zh:c741a3fe7d085593a160e79596bd237afc9503c836abcc95fd627554cdf16ec0",
+    "zh:f6763e96485e1ea5b67a33bbd04042e412508b2b06946acf957fb68a314d893e",
+    "zh:fc7144577ea7d6e05c276b54a9f8f8609be7b4d0a128aa45f233a4b0e5cbf090",
+  ]
+}

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -1,0 +1,25 @@
+terraform {
+  source = "../../../aws//alarms"
+}
+
+dependencies {
+  paths = ["../api"]
+}
+
+dependency "api" {
+  config_path = "../api"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    api_function_name = "github-secret-scanning-api"
+  }
+}
+
+inputs = {
+  api_function_name = dependency.api.outputs.function_name
+}  
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
## Summary
Add API alarms that trigger when errors are logged or a secret is detected.

## Related
- Closes #15
- cds-snc/site-reliability-engineering#812
- cds-snc/notification-planning#838