### PR TITLE
fix: slack notify function name

### DIFF
--- a/terragrunt/aws/alarms/slack.tf
+++ b/terragrunt/aws/alarms/slack.tf
@@ -1,7 +1,7 @@
 module "cloudwatch_alarms_slack" {
   source = "github.com/cds-snc/terraform-modules?ref=v5.0.2//notify_slack"
 
-  function_name     = var.product_name
+  function_name     = "${var.product_name}-notify-slack"
   project_name      = var.product_name
   slack_webhook_url = var.slack_webhook_url
   sns_topic_arns = [

--- a/terragrunt/aws/api/sentinel.tf
+++ b/terragrunt/aws/api/sentinel.tf
@@ -1,6 +1,6 @@
 module "sentinel_forwarder" {
   source            = "github.com/cds-snc/terraform-modules?ref=v5.0.1//sentinel_forwarder"
-  function_name     = var.product_name
+  function_name     = "${var.product_name}-sentinel"
   billing_tag_value = var.billing_code
 
   layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:42"


### PR DESCRIPTION
## Summary
Update the Slack alarm notification lambda's name.

## Related
- cds-snc/site-reliability-engineering#812
- cds-snc/notification-planning#838