### PR TITLE
feat: block direct requests to the Lambda function

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -13,6 +13,7 @@ env:
   TERRAGRUNT_VERSION: 0.43.2
   AWS_REGION: ca-central-1
   TF_VAR_api_config: ${{ secrets.API_CONFIG }}
+  TF_VAR_cloudfront_header: ${{ secrets.CLOUDFRONT_HEADER }}
   TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -13,6 +13,7 @@ env:
   TERRAGRUNT_VERSION: 0.43.2
   AWS_REGION: ca-central-1
   TF_VAR_api_config: ${{ secrets.API_CONFIG }}
+  TF_VAR_cloudfront_header: ${{ secrets.CLOUDFRONT_HEADER }}
   TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ When GitHub detects our registered secrets in public repositories, it will send 
 1. Start the [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers).
 1. Make a copy of `api/.env.example` and name it `api/.env`.
 1. Run `cd api && make dev` and access on `localhost:8000`.
+
+Your requests to the API will need an `X-CloudFront-Header` with the value you set in the `api/.env` file for `CLOUDFRONT_HEADER`:
+
+```sh
+curl http://localhost:8000/version \
+    -H "X-CloudFront-Header: some-secret-value"
+```
+
+Alternatively, you can set `CLOUDFRONT_HEADER=localhost` to disable this check.

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,2 +1,3 @@
+CLOUDFRONT_HEADER=some-secret-value
 GITHUB_PUBLIC_KEYS_URL=https://api.github.com/meta/public_keys/secret_scanning
 GITHUB_TOKEN=your-github-token

--- a/api/main.py
+++ b/api/main.py
@@ -3,8 +3,9 @@ Main API entrypoint
 """
 from fastapi import FastAPI
 from mangum import Mangum
+from starlette.middleware.base import BaseHTTPMiddleware
 from routers import alerts, ops
-
+from middleware.cloudfront import check_header
 
 app = FastAPI(
     title="GitHub Secret Scanning Alerts API",
@@ -14,5 +15,6 @@ app = FastAPI(
 
 app.include_router(alerts.router)
 app.include_router(ops.router)
+app.add_middleware(BaseHTTPMiddleware, dispatch=check_header)
 
 handler = Mangum(app)

--- a/api/middleware/cloudfront.py
+++ b/api/middleware/cloudfront.py
@@ -1,0 +1,21 @@
+"""
+Middleware to validate that the CloudFront header is present
+on the request.  This is to ensure that the API is not
+directly accessible through the Lambda function URL.
+"""
+from os import environ
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+CLOUDFRONT_HEADER = environ.get("CLOUDFRONT_HEADER", None)
+
+
+async def check_header(request: Request, call_next):
+    "Check if the CloudFront header is present"
+    header = request.headers.get("X-CloudFront-Header", None)
+    if CLOUDFRONT_HEADER != "localhost" and CLOUDFRONT_HEADER != header:
+        return JSONResponse(
+            {"status": "ERROR", "message": "Direct access to the API is not allowed"},
+            status_code=403,
+        )
+    return await call_next(request)

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
 env =  
+    CLOUDFRONT_HEADER=localhost
     GITHUB_PUBLIC_KEYS_URL=https://api.github.com/meta/public_keys/secret_scanning
     GITHUB_TOKEN=your-github-token

--- a/api/tests/middleware/test_cloudfront.py
+++ b/api/tests/middleware/test_cloudfront.py
@@ -1,0 +1,20 @@
+# pylint: disable=missing-docstring,line-too-long
+from unittest.mock import patch
+
+
+@patch("middleware.cloudfront.CLOUDFRONT_HEADER", "foo")
+def test_check_header_present(client):
+    response = client.get("/version", headers={"X-CloudFront-Header": "foo"})
+    assert response.status_code == 200
+
+
+@patch("middleware.cloudfront.CLOUDFRONT_HEADER", "foo")
+def test_check_header_bad_value(client):
+    response = client.get("/version", headers={"X-CloudFront-Header": "bar"})
+    assert response.status_code == 403
+
+
+@patch("middleware.cloudfront.CLOUDFRONT_HEADER", "foo")
+def test_check_header_missing(client):
+    response = client.get("/version")
+    assert response.status_code == 403

--- a/api/tests/middleware/test_cloudfront.py
+++ b/api/tests/middleware/test_cloudfront.py
@@ -18,3 +18,9 @@ def test_check_header_bad_value(client):
 def test_check_header_missing(client):
     response = client.get("/version")
     assert response.status_code == 403
+
+
+@patch("middleware.cloudfront.CLOUDFRONT_HEADER", "localhost")
+def test_check_header_localhost_bypass(client):
+    response = client.get("/version")
+    assert response.status_code == 200

--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -15,6 +15,11 @@ resource "aws_cloudfront_distribution" "api" {
       origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
+
+    custom_header {
+      name  = "X-CloudFront-Header"
+      value = var.cloudfront_header
+    }
   }
 
   # Optimized caching for all GET/HEAD requests

--- a/terragrunt/aws/cloudfront/inputs.tf
+++ b/terragrunt/aws/cloudfront/inputs.tf
@@ -8,6 +8,12 @@ variable "api_function_url" {
   type        = string
 }
 
+variable "cloudfront_header" {  
+  description = "Header that gets added to all origin requests by CloudFront.  The API validates that this header is present and has the expected value."
+  type = string
+  sensitive = true
+}
+
 variable "enable_waf" {
   description = "(Optional) Should the WAF be enabled? Defaults to true."
   type        = bool

--- a/terragrunt/aws/cloudfront/inputs.tf
+++ b/terragrunt/aws/cloudfront/inputs.tf
@@ -8,10 +8,10 @@ variable "api_function_url" {
   type        = string
 }
 
-variable "cloudfront_header" {  
+variable "cloudfront_header" {
   description = "Header that gets added to all origin requests by CloudFront.  The API validates that this header is present and has the expected value."
-  type = string
-  sensitive = true
+  type        = string
+  sensitive   = true
 }
 
 variable "enable_waf" {


### PR DESCRIPTION
## Summary
Add a custom middleware that checks for the existence of a secret header value.  If the header is not present, prevent access to the API.

This is being done to prevent users from bypassing the WAF + CloudFront and using the Lambda function URL directly.

## Related
- Closes #14 
- cds-snc/site-reliability-engineering#812
- cds-snc/notification-planning#838