### PR TITLE
feat: clear CloudFront cache on deploy

### DIFF
--- a/.github/workflows/docker-build-push-production.yml
+++ b/.github/workflows/docker-build-push-production.yml
@@ -88,3 +88,6 @@ jobs:
 
       - name: Logout of Amazon ECR
         run: docker logout ${{ steps.login-ecr.outputs.registry }}
+
+      - name: CloudFront cache invalidate
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DIST_ID }} --paths "/*"


### PR DESCRIPTION
## Summary
Update the Docker build/push workflow to invalidate the service's CloudFront cache when a new Docker image is deployed.