### PR TITLE
fix: pin urllib3 below v2

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ fastapi==0.95.1
 mangum==0.17.0
 python-dotenv==1.0.0
 requests==2.30.0
+urllib3<2 # Boto currently does not support urllib3 v2


### PR DESCRIPTION
# Summary
Boto3 currently does not support urllib v2 and throws an error.

# Related
- boto/botocore#2926