### PR TITLE
fix: Terraform module reference

### DIFF
--- a/terragrunt/aws/alarms/slack.tf
+++ b/terragrunt/aws/alarms/slack.tf
@@ -1,5 +1,5 @@
 module "cloudwatch_alarms_slack" {
-  source = "github.com/cds-snc/terraform-modules?ref=v6.1.1//notify_slack"
+  source = "github.com/cds-snc/terraform-modules//notify_slack?ref=v6.1.1"
 
   function_name     = "${var.product_name}-notify-slack"
   project_name      = var.product_name

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -1,5 +1,5 @@
 module "api" {
-  source    = "github.com/cds-snc/terraform-modules?ref=v6.1.1//lambda"
+  source    = "github.com/cds-snc/terraform-modules//lambda?ref=v6.1.1"
   name      = "${var.product_name}-api"
   ecr_arn   = aws_ecr_repository.api.arn
   image_uri = "${aws_ecr_repository.api.repository_url}:latest"

--- a/terragrunt/aws/api/sentinel.tf
+++ b/terragrunt/aws/api/sentinel.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "sentinel_forwarder" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v6.1.1//sentinel_forwarder"
+  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v6.1.1"
   function_name     = "${var.product_name}-sentinel"
   billing_tag_value = var.billing_code
 


### PR DESCRIPTION
# Summary
Update the version reference for the Terraform
modules to be after the module sub-directory.