### PR TITLE
Adding opsgenie alert integration when a secret is detected

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -17,6 +17,7 @@ env:
   TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+  TF_VAR_opsgenie_alarm_webhook_url: ${{ secrets.OPSGENIE_ALARM_WEBHOOK_URL }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -17,6 +17,7 @@ env:
   TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+  TF_VAR_opsgenie_alarm_webhook_url: ${{ secrets.OPSGENIE_ALARM_WEBHOOK_URL }}
 
 permissions:
   id-token: write

--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -8,3 +8,10 @@ variable "slack_webhook_url" {
   type        = string
   sensitive   = true
 }
+
+variable "opsgenie_alarm_webhook_url" {
+  description = "The URL of the opsgenie webhook."
+  type        = string
+  sensitive   = true
+}
+

--- a/terragrunt/aws/alarms/sns.tf
+++ b/terragrunt/aws/alarms/sns.tf
@@ -20,6 +20,15 @@ resource "aws_sns_topic_subscription" "cloudwatch_alarm" {
   endpoint  = var.slack_webhook_url
 }
 
+# SNS subscription for OpsGenie
+resource "aws_sns_topic_subscription" "alert_to_sns_to_opsgenie" {
+  topic_arn              = aws_sns_topic.cloudwatch_alarm.arn
+  protocol               = "https"
+  endpoint               = var.opsgenie_alarm_webhook_url
+  raw_message_delivery   = false
+  endpoint_auto_confirms = true
+}
+
 #
 # KMS: SNS topic encryption keys
 #


### PR DESCRIPTION
# Summary | Résumé

Adding the webhook url and sns topic subscription to include opsgenie so that the opsgenie hook is used to be notified. 2 questions arise from this though:
1. The notify people will not have access to the SRE tools AWS account so therefore they will not be able to see the cloudwatch logs to see which secret is detected. Should we add the cloudwatch message to the description or is there a better way to do it?
2. Is there an ideal way to test this? 