### PR TITLE
Whitelisting Notify testing key that is used in the unit tests

### DIFF
--- a/terragrunt/aws/alert_compromise/functions/broadcast_alert.py
+++ b/terragrunt/aws/alert_compromise/functions/broadcast_alert.py
@@ -21,7 +21,7 @@ def lambda_handler(event, context):
     decoded_event = json.loads(gzip.decompress(base64.b64decode(event['awslogs']['data'])))
     message = decoded_event['logEvents'][0]['message']
     # Double check that the message received contains a secret
-    if ("Secret detected:" in message ):
+    if ("Secret detected:" in message) and ("gcntfy-api-key-blah-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000" not in message):
         message_array = re.split("\s", message)
         for element in message_array:
             # Retrieve the api_key and the github_repo from the message


### PR DESCRIPTION
# Summary | Résumé

Whitelist the notify api key so that we don't get alerted anymore at least not to ping the on call people. 