### PR TITLE
Whitelisting dsp-testing so that it does not trigger an alarm 

### DIFF
--- a/terragrunt/aws/alert_compromise/functions/broadcast_alert.py
+++ b/terragrunt/aws/alert_compromise/functions/broadcast_alert.py
@@ -21,7 +21,7 @@ def lambda_handler(event, context):
     decoded_event = json.loads(gzip.decompress(base64.b64decode(event['awslogs']['data'])))
     message = decoded_event['logEvents'][0]['message']
     # Double check that the message received contains a secret
-    if ("Secret detected:" in message ):
+    if ("Secret detected:" in message and "dsp-testing" not in message):
         message_array = re.split("\s", message)
         for element in message_array:
             # Retrieve the api_key and the github_repo from the message


### PR DESCRIPTION
# Summary | Résumé

Whitelist Github testing of Notify API key so that it does not trigger a notification. 