### PR TITLE
Whitelist notify test api key

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -17,6 +17,7 @@ env:
   TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+  TF_VAR_notify_test_api_key: ${{ secrets.NOTIFY_TEST_API_KEY }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -17,7 +17,7 @@ env:
   TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-  TF_VAR_notify_test_api_key: ${{ secrets.NOTIFY_TEST_API_KEY }}
+  TF_VAR_notify_doc_api_key: ${{ secrets.NOTIFY_DOC_API_KEY }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -17,6 +17,7 @@ env:
   TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+  TF_VAR_notify_test_api_key: ${{ secrets.NOTIFY_TEST_API_KEY }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -17,7 +17,7 @@ env:
   TF_VAR_log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
   TF_VAR_log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-  TF_VAR_notify_test_api_key: ${{ secrets.NOTIFY_TEST_API_KEY }}
+  TF_VAR_notify_doc_api_key: ${{ secrets.NOTIFY_DOC_API_KEY }}
 
 permissions:
   id-token: write

--- a/terragrunt/aws/alert_compromise/functions/broadcast_alert.py
+++ b/terragrunt/aws/alert_compromise/functions/broadcast_alert.py
@@ -28,6 +28,12 @@ def lambda_handler(event, context):
     # List of items to ignore as these are from GitHub testing
     ignore_terms = ["dsp-testing", "example.com", "gcntfy-github-test-revoked"]
 
+    # get the notify_api_key from the environment variable
+    notify_test_api_key = os.environ["notify_test_api_key"]
+
+    # Add the notify_api_key to the ignore_terms list
+    ignore_terms.append(notify_test_api_key)
+
     print("Starting...")
     # Double check that the message received contains a secret
     if "Secret detected:" in message and not any(

--- a/terragrunt/aws/alert_compromise/functions/broadcast_alert.py
+++ b/terragrunt/aws/alert_compromise/functions/broadcast_alert.py
@@ -34,10 +34,10 @@ def lambda_handler(event, context):
     ]
 
     # get the notify_api_key from the environment variable
-    notify_test_api_key = os.environ["notify_test_api_key"]
+    notify_doc_api_key = os.environ["notify_doc_api_key"]
 
     # Add the notify_api_key to the ignore_terms list
-    ignore_terms.append(notify_test_api_key)
+    ignore_terms.append(notify_doc_api_key)
 
     print("Starting...")
     # Double check that the message received contains a secret

--- a/terragrunt/aws/alert_compromise/functions/broadcast_alert.py
+++ b/terragrunt/aws/alert_compromise/functions/broadcast_alert.py
@@ -26,7 +26,12 @@ def lambda_handler(event, context):
     message = decoded_event["logEvents"][0]["message"]
 
     # List of items to ignore as these are from GitHub testing
-    ignore_terms = ["dsp-testing", "example.com", "gcntfy-github-test-revoked"]
+    ignore_terms = [
+        "dsp-testing",
+        "example.com",
+        "gcntfy-github-test-revoked",
+        "cds-snc/notification-documentation",
+    ]
 
     # get the notify_api_key from the environment variable
     notify_test_api_key = os.environ["notify_test_api_key"]

--- a/terragrunt/aws/alert_compromise/functions/broadcast_alert_tests.py
+++ b/terragrunt/aws/alert_compromise/functions/broadcast_alert_tests.py
@@ -8,7 +8,12 @@ from broadcast_alert import lambda_handler
 @mock.patch("broadcast_alert.gzip")
 @mock.patch("broadcast_alert.base64")
 @mock.patch(
-    "os.environ", {"sns_topic_arn": "fake_topic_arn", "subject": "Fake Subject", "notify_test_api_key": "gcntfy-some-test-key-11111"}
+    "os.environ",
+    {
+        "sns_topic_arn": "fake_topic_arn",
+        "subject": "Fake Subject",
+        "notify_test_api_key": "gcntfy-notify-test-key-11111",
+    },
 )
 def test_lambda_handler_secret_detected(
     mock_base64, mock_gzip, mock_json_loads, mock_boto3_client
@@ -36,7 +41,12 @@ def test_lambda_handler_secret_detected(
 @mock.patch("broadcast_alert.gzip")
 @mock.patch("broadcast_alert.base64")
 @mock.patch(
-    "os.environ", {"sns_topic_arn": "fake_topic_arn", "subject": "Fake Subject", "notify_test_api_key": "gcntfy-some-test-key-11111"}
+    "os.environ",
+    {
+        "sns_topic_arn": "fake_topic_arn",
+        "subject": "Fake Subject",
+        "notify_test_api_key": "gcntfy-notify-test-key-11111",
+    },
 )
 @pytest.mark.parametrize(
     "message",
@@ -44,7 +54,7 @@ def test_lambda_handler_secret_detected(
         "Secret detected: token='gcntfy-some-test-key-00000' type='cds_canada_notify_api_key' url='https://example.com/cds-snc/some-repo' source='commit'",
         "Secret detected: token='gcntfy-some-test-key-00000' type='cds_canada_notify_api_key' url='https://github.com/dsp-testing/some-repo' source='commit'",
         "Secret detected: token='gcntfy-github-test-revoked' type='cds_canada_notify_api_key' url='https://example.com/cds-snc/some-repo' source='commit'",
-        "Secret detected: token='gcntfy-some-test-key-11111' type='cds_canada_notify_api_key' url='https://whatever.com/cds-snc/some-repo' source='commit'"
+        "Secret detected: token='gcntfy-notify-test-key-11111' type='cds_canada_notify_api_key' url='https://whatever.com/cds-snc/some-repo' source='commit'",
     ],
 )
 def test_lambda_handler_secret_ignored(

--- a/terragrunt/aws/alert_compromise/functions/broadcast_alert_tests.py
+++ b/terragrunt/aws/alert_compromise/functions/broadcast_alert_tests.py
@@ -8,7 +8,7 @@ from broadcast_alert import lambda_handler
 @mock.patch("broadcast_alert.gzip")
 @mock.patch("broadcast_alert.base64")
 @mock.patch(
-    "os.environ", {"sns_topic_arn": "fake_topic_arn", "subject": "Fake Subject"}
+    "os.environ", {"sns_topic_arn": "fake_topic_arn", "subject": "Fake Subject", "notify_test_api_key": "gcntfy-some-test-key-11111"}
 )
 def test_lambda_handler_secret_detected(
     mock_base64, mock_gzip, mock_json_loads, mock_boto3_client
@@ -36,7 +36,7 @@ def test_lambda_handler_secret_detected(
 @mock.patch("broadcast_alert.gzip")
 @mock.patch("broadcast_alert.base64")
 @mock.patch(
-    "os.environ", {"sns_topic_arn": "fake_topic_arn", "subject": "Fake Subject"}
+    "os.environ", {"sns_topic_arn": "fake_topic_arn", "subject": "Fake Subject", "notify_test_api_key": "gcntfy-some-test-key-11111"}
 )
 @pytest.mark.parametrize(
     "message",
@@ -44,6 +44,7 @@ def test_lambda_handler_secret_detected(
         "Secret detected: token='gcntfy-some-test-key-00000' type='cds_canada_notify_api_key' url='https://example.com/cds-snc/some-repo' source='commit'",
         "Secret detected: token='gcntfy-some-test-key-00000' type='cds_canada_notify_api_key' url='https://github.com/dsp-testing/some-repo' source='commit'",
         "Secret detected: token='gcntfy-github-test-revoked' type='cds_canada_notify_api_key' url='https://example.com/cds-snc/some-repo' source='commit'",
+        "Secret detected: token='gcntfy-some-test-key-11111' type='cds_canada_notify_api_key' url='https://whatever.com/cds-snc/some-repo' source='commit'"
     ],
 )
 def test_lambda_handler_secret_ignored(

--- a/terragrunt/aws/alert_compromise/functions/broadcast_alert_tests.py
+++ b/terragrunt/aws/alert_compromise/functions/broadcast_alert_tests.py
@@ -12,7 +12,7 @@ from broadcast_alert import lambda_handler
     {
         "sns_topic_arn": "fake_topic_arn",
         "subject": "Fake Subject",
-        "notify_test_api_key": "gcntfy-notify-test-key-11111",
+        "notify_doc_api_key": "gcntfy-notify-test-key-11111",
     },
 )
 def test_lambda_handler_secret_detected(
@@ -45,7 +45,7 @@ def test_lambda_handler_secret_detected(
     {
         "sns_topic_arn": "fake_topic_arn",
         "subject": "Fake Subject",
-        "notify_test_api_key": "gcntfy-notify-test-key-11111",
+        "notify_doc_api_key": "gcntfy-notify-test-key-11111",
     },
 )
 @pytest.mark.parametrize(

--- a/terragrunt/aws/alert_compromise/functions/broadcast_alert_tests.py
+++ b/terragrunt/aws/alert_compromise/functions/broadcast_alert_tests.py
@@ -53,6 +53,7 @@ def test_lambda_handler_secret_detected(
     [
         "Secret detected: token='gcntfy-some-test-key-00000' type='cds_canada_notify_api_key' url='https://example.com/cds-snc/some-repo' source='commit'",
         "Secret detected: token='gcntfy-some-test-key-00000' type='cds_canada_notify_api_key' url='https://github.com/dsp-testing/some-repo' source='commit'",
+        "Secret detected: token='gcntfy-some-test-key-00000' type='cds_canada_notify_api_key' url='https://github.com/cds-snc/notification-documentation' source='commit'",
         "Secret detected: token='gcntfy-github-test-revoked' type='cds_canada_notify_api_key' url='https://example.com/cds-snc/some-repo' source='commit'",
         "Secret detected: token='gcntfy-notify-test-key-11111' type='cds_canada_notify_api_key' url='https://whatever.com/cds-snc/some-repo' source='commit'",
     ],

--- a/terragrunt/aws/alert_compromise/iam.tf
+++ b/terragrunt/aws/alert_compromise/iam.tf
@@ -45,10 +45,15 @@ resource "aws_iam_policy" "ssm_get_parameters_policy" {
 
   policy = jsonencode({
     Version = "2012-10-17",
-    Statement = [{
-      Action   = "ssm:GetParameters",
-      Effect   = "Allow",
-      Resource = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/notify_test_api_key"
-    }]
+    Statement = [
+      {
+        Action = [
+          "ssm:GetParameters"
+        ]
+        Sid      = "AllowSSMGetParameters",
+        Effect   = "Allow",
+        Resource = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/notify_test_api_key"
+      }
+    ]
   })
 }

--- a/terragrunt/aws/alert_compromise/iam.tf
+++ b/terragrunt/aws/alert_compromise/iam.tf
@@ -51,7 +51,7 @@ resource "aws_iam_role_policy" "ssm_get_parameters_policy" {
         ]
         Sid      = "AllowSSMGetParameters",
         Effect   = "Allow",
-        Resource = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/notify_test_api_key"
+        Resource = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/notify_doc_api_key"
       }
     ]
   })

--- a/terragrunt/aws/alert_compromise/iam.tf
+++ b/terragrunt/aws/alert_compromise/iam.tf
@@ -38,9 +38,8 @@ resource "aws_iam_role_policy" "publish_to_sns" {
 }
 
 # IAM Policy for Lambda Function to get SSM Parameters
-resource "aws_iam_policy" "ssm_get_parameters_policy" {
+resource "aws_iam_role_policy" "ssm_get_parameters_policy" {
   name        = "ssm_get_parameters_policy"
-  description = "Policy for allowing access to SSM GetParameters"
   role        = aws_iam_role.group_broadcast_alert_role.id
 
   policy = jsonencode({

--- a/terragrunt/aws/alert_compromise/iam.tf
+++ b/terragrunt/aws/alert_compromise/iam.tf
@@ -1,35 +1,54 @@
 # IAM Role for Lambda Function
 resource "aws_iam_role" "group_broadcast_alert_role" {
-  name = "group_broadcast_alert_role"
-
+  name                = "group_broadcast_alert_role"
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
   assume_role_policy = jsonencode({
-    Version = "2012-10-17",
+    Version = "2012-10-17"
     Statement = [
       {
-        Action = "sts:AssumeRole",
-        Effect = "Allow",
-        Principal = { Service = "lambda.amazonaws.com" },
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
       },
-    ],
+    ]
   })
-
-  inline_policy {
-    name = "lambda_permissions"
-    policy = data.aws_iam_policy_document.lambda_permissions.json
-  }
 }
 
-# IAM Policy for Lambda Function
-data "aws_iam_policy_document" "lambda_permissions" {
-  statement {
-    actions   = ["ssm:GetParameters"]
-    effect    = "Allow"
-    resources = [aws_ssm_parameter.notify_test_api_key.arn]
-  }
+# IAM Policy for Lambda Function to publish to SNS
+resource "aws_iam_role_policy" "publish_to_sns" {
+  name = "publish_to_sns"
+  role = aws_iam_role.group_broadcast_alert_role.id
 
-  statement {
-    actions   = ["sns:Publish"]
-    effect    = "Allow"
-    resources = ["arn:aws:sns:${var.region}:${var.account_id}:${var.sns_topic}"]
-  }
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "sns:Publish"
+        ]
+        Effect   = "Allow"
+        Sid      = "AllowSnsActions"
+        Resource = "arn:aws:sns:${var.region}:${var.account_id}:${var.sns_topic}"
+      }
+    ]
+  })
+}
+
+# IAM Policy for Lambda Function to get SSM Parameters
+resource "aws_iam_policy" "ssm_get_parameters_policy" {
+  name        = "ssm_get_parameters_policy"
+  description = "Policy for allowing access to SSM GetParameters"
+  role        = aws_iam_role.group_broadcast_alert_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Action   = "ssm:GetParameters",
+      Effect   = "Allow",
+      Resource = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/notify_test_api_key"
+    }]
+  })
 }

--- a/terragrunt/aws/alert_compromise/iam.tf
+++ b/terragrunt/aws/alert_compromise/iam.tf
@@ -39,8 +39,8 @@ resource "aws_iam_role_policy" "publish_to_sns" {
 
 # IAM Policy for Lambda Function to get SSM Parameters
 resource "aws_iam_role_policy" "ssm_get_parameters_policy" {
-  name        = "ssm_get_parameters_policy"
-  role        = aws_iam_role.group_broadcast_alert_role.id
+  name = "ssm_get_parameters_policy"
+  role = aws_iam_role.group_broadcast_alert_role.id
 
   policy = jsonencode({
     Version = "2012-10-17",

--- a/terragrunt/aws/alert_compromise/iam.tf
+++ b/terragrunt/aws/alert_compromise/iam.tf
@@ -1,38 +1,35 @@
 # IAM Role for Lambda Function
 resource "aws_iam_role" "group_broadcast_alert_role" {
-  name                = "group_broadcast_alert_role"
-  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+  name = "group_broadcast_alert_role"
+
   assume_role_policy = jsonencode({
-    Version = "2012-10-17"
+    Version = "2012-10-17",
     Statement = [
       {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Sid    = ""
-        Principal = {
-          Service = "lambda.amazonaws.com"
-        }
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = { Service = "lambda.amazonaws.com" },
       },
-    ]
+    ],
   })
+
+  inline_policy {
+    name = "lambda_permissions"
+    policy = data.aws_iam_policy_document.lambda_permissions.json
+  }
 }
 
 # IAM Policy for Lambda Function
-resource "aws_iam_role_policy" "publish_to_sns" {
-  name = "publish_to_sns"
-  role = aws_iam_role.group_broadcast_alert_role.id
+data "aws_iam_policy_document" "lambda_permissions" {
+  statement {
+    actions   = ["ssm:GetParameters"]
+    effect    = "Allow"
+    resources = [aws_ssm_parameter.notify_test_api_key.arn]
+  }
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = [
-          "sns:Publish"
-        ]
-        Effect   = "Allow"
-        Sid      = "AllowSnsActions"
-        Resource = "arn:aws:sns:${var.region}:${var.account_id}:${var.sns_topic}"
-      }
-    ]
-  })
+  statement {
+    actions   = ["sns:Publish"]
+    effect    = "Allow"
+    resources = ["arn:aws:sns:${var.region}:${var.account_id}:${var.sns_topic}"]
+  }
 }

--- a/terragrunt/aws/alert_compromise/input.tf
+++ b/terragrunt/aws/alert_compromise/input.tf
@@ -32,7 +32,7 @@ variable "api_function_name" {
 }
 
 variable "notify_test_api_key" {
-  description = "The Notify API test key that we can be used for testing."  
+  description = "The Notify API test key that we can be used for testing."
   type        = string
   sensitive   = true
 }

--- a/terragrunt/aws/alert_compromise/input.tf
+++ b/terragrunt/aws/alert_compromise/input.tf
@@ -31,7 +31,7 @@ variable "api_function_name" {
   type        = string
 }
 
-variable "notify_test_api_key" {
+variable "notify_doc_api_key" {
   description = "The Notify API test key that we can be used for testing."
   type        = string
   sensitive   = true

--- a/terragrunt/aws/alert_compromise/input.tf
+++ b/terragrunt/aws/alert_compromise/input.tf
@@ -30,3 +30,9 @@ variable "api_function_name" {
   description = "The name of the api lambda function"
   type        = string
 }
+
+variable "notify_test_api_key" {
+  description = "The Notify API test key that we can be used for testing."  
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/aws/alert_compromise/lambda.tf
+++ b/terragrunt/aws/alert_compromise/lambda.tf
@@ -30,9 +30,9 @@ resource "aws_lambda_function" "broadcast_alert" {
   }
   environment {
     variables = {
-      sns_topic_arn       = "arn:aws:sns:${var.region}:${var.account_id}:${var.sns_topic}"
-      subject             = var.subject_message
-      notify_test_api_key = var.notify_test_api_key
+      sns_topic_arn      = "arn:aws:sns:${var.region}:${var.account_id}:${var.sns_topic}"
+      subject            = var.subject_message
+      notify_doc_api_key = var.notify_doc_api_key
     }
   }
   depends_on = [

--- a/terragrunt/aws/alert_compromise/lambda.tf
+++ b/terragrunt/aws/alert_compromise/lambda.tf
@@ -30,8 +30,9 @@ resource "aws_lambda_function" "broadcast_alert" {
   }
   environment {
     variables = {
-      sns_topic_arn = "arn:aws:sns:${var.region}:${var.account_id}:${var.sns_topic}"
-      subject       = var.subject_message
+      sns_topic_arn       = "arn:aws:sns:${var.region}:${var.account_id}:${var.sns_topic}"
+      subject             = var.subject_message
+      notify_test_api_key = var.notify_test_api_key
     }
   }
   depends_on = [

--- a/terragrunt/aws/alert_compromise/secrets.tf
+++ b/terragrunt/aws/alert_compromise/secrets.tf
@@ -1,0 +1,10 @@
+resource "aws_ssm_parameter" "notify_test_api_key" {
+  name  = "notify_test_api_key"
+  type  = "SecureString"
+  value = var.notify_test_api_key
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}

--- a/terragrunt/aws/alert_compromise/secrets.tf
+++ b/terragrunt/aws/alert_compromise/secrets.tf
@@ -1,7 +1,7 @@
-resource "aws_ssm_parameter" "notify_test_api_key" {
-  name  = "notify_test_api_key"
+resource "aws_ssm_parameter" "notify_doc_api_key" {
+  name  = "notify_doc_api_key"
   type  = "SecureString"
-  value = var.notify_test_api_key
+  value = var.notify_doc_api_key
 
   tags = {
     CostCentre = var.billing_code

--- a/terragrunt/env/production/alert_compromise/terragrunt.hcl
+++ b/terragrunt/env/production/alert_compromise/terragrunt.hcl
@@ -18,7 +18,7 @@ dependency "api" {
 
 inputs = {
   api_function_name     = dependency.api.outputs.function_name
-  notify_test_api_key  = "test-api-key"
+  notify_doc_api_key  = "test-api-key"
 }  
 
 include {

--- a/terragrunt/env/production/alert_compromise/terragrunt.hcl
+++ b/terragrunt/env/production/alert_compromise/terragrunt.hcl
@@ -17,7 +17,8 @@ dependency "api" {
 }
 
 inputs = {
-  api_function_name = dependency.api.outputs.function_name
+  api_function_name     = dependency.api.outputs.function_name
+  notifiy_test_api_key  = "test-api-key"
 }  
 
 include {

--- a/terragrunt/env/production/alert_compromise/terragrunt.hcl
+++ b/terragrunt/env/production/alert_compromise/terragrunt.hcl
@@ -18,7 +18,7 @@ dependency "api" {
 
 inputs = {
   api_function_name     = dependency.api.outputs.function_name
-  notifiy_test_api_key  = "test-api-key"
+  notify_test_api_key  = "test-api-key"
 }  
 
 include {

--- a/terragrunt/env/staging/alert_compromise/terragrunt.hcl
+++ b/terragrunt/env/staging/alert_compromise/terragrunt.hcl
@@ -18,7 +18,7 @@ dependency "api" {
 
 inputs = {
   api_function_name     = dependency.api.outputs.function_name
-  notify_test_api_key  = "test-api-key"
+  notify_doc_api_key  = "test-api-key"
 }  
 
 include {

--- a/terragrunt/env/staging/alert_compromise/terragrunt.hcl
+++ b/terragrunt/env/staging/alert_compromise/terragrunt.hcl
@@ -17,7 +17,8 @@ dependency "api" {
 }
 
 inputs = {
-  api_function_name = dependency.api.outputs.function_name
+  api_function_name     = dependency.api.outputs.function_name
+  notifiy_test_api_key  = "test-api-key"
 }  
 
 include {

--- a/terragrunt/env/staging/alert_compromise/terragrunt.hcl
+++ b/terragrunt/env/staging/alert_compromise/terragrunt.hcl
@@ -18,7 +18,7 @@ dependency "api" {
 
 inputs = {
   api_function_name     = dependency.api.outputs.function_name
-  notifiy_test_api_key  = "test-api-key"
+  notify_test_api_key  = "test-api-key"
 }  
 
 include {


### PR DESCRIPTION
# Summary | Résumé

This PR whitelists a fake notify test api key that can be used for documentation or other purposes. The notify API test key is stored in the secrets github variables and then is stored in an ssm parameter. This is done so that we don't actually commit the key and therefore trigger the alarms. Also, this way, we can easily change the test API key value using the github action secrets as opposed to releasing a new PR. Also, I whitelisted the whole cds-snc/notification-documentation repo. 

@gcharest / @patheard - On second thoughts, I probably don't need to store this as a secret. Jimmy brought up a good point that made me think about this. There should be no issues in just passing the variable to the lambda environment variables and not storing it in a secret right? Interested to see what you both think. 