### PR TITLE
Whitelisting notification documentation repo in alarms

### DIFF
--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -11,6 +11,7 @@ locals {
     "dsp-testing",
     "example.com",
     "gcntfy-github-test-revoked",
+    "cds-snc/notification-documentation",
   ]
   secret_detected_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.secret_detected_metric)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.secret_detected_metric_skip)}*\"]"
 }


### PR DESCRIPTION
# Summary | Résumé

Whitelist notification documentation repo in the alarms 