### PR TITLE
fix: rollback to `urllib3 < 2`

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,4 +3,4 @@ fastapi==0.110.0
 mangum==0.17.0
 python-dotenv==1.0.1
 requests==2.31.0
-urllib3<2.1 # Boto currently does not support urllib3 > 2.1
+urllib3<2 # Boto currently does not support urllib3 2+


### PR DESCRIPTION
# Summary
There is still an issue trying to use urllib3 2+.  AWS is looking at this and will have a fix eventually.

# Related
- #232 