### PR TITLE
chore: update to latest Sentinel Forwarder module

### DIFF
--- a/terragrunt/aws/api/sentinel.tf
+++ b/terragrunt/aws/api/sentinel.tf
@@ -4,11 +4,11 @@ locals {
 }
 
 module "sentinel_forwarder" {
-  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v9.2.7"
+  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v9.3.8"
   function_name     = "${var.product_name}-sentinel"
   billing_tag_value = var.billing_code
 
-  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:54"
+  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:125"
 
   customer_id = var.log_analytics_workspace_id
   shared_key  = var.log_analytics_workspace_key


### PR DESCRIPTION
# Summary
Update to the Terraform Sentinel Forwarder module that does not store its authentication credentials as Lambda env vars.

# Related
- https://github.com/cds-snc/platform-core-services/issues/557
- https://github.com/cds-snc/site-reliability-engineering/issues/1215