### PR TITLE
fix: use CDS Trivy vulnerability database

### DIFF
--- a/.github/workflows/docker-build-push-production.yml
+++ b/.github/workflows/docker-build-push-production.yml
@@ -79,7 +79,9 @@ jobs:
             --image-uri $REGISTRY/${{ matrix.image }}:$GITHUB_SHA  > /dev/null 2>&1
 
       - name: Docker generate SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@598deeaed48ab3bb0df85f0ed124ba53f0ade385 # v3.1.0
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         with:
           docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.GITHUB_SHA }}"
           dockerfile_path: "${{ matrix.image }}/Dockerfile"

--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -38,7 +38,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
       - name: Docker vulnerability scan
-        uses: cds-snc/security-tools/.github/actions/docker-scan@598deeaed48ab3bb0df85f0ed124ba53f0ade385 # v3.1.0
+        uses: cds-snc/security-tools/.github/actions/docker-scan@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         with:
           docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:latest"
           dockerfile_path: "${{ matrix.image }}/Dockerfile"


### PR DESCRIPTION
# Summary
Update the Docker scan actions to use a self-hosted Trivy vulnerability database. This is being done to address the rate limiting of the publicly hosted database.

# Related
- https://github.com/cds-snc/platform-core-services/issues/597