### PR TITLE
Restrict API Lambda invocation to the CloudFront distribution

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -22,5 +22,5 @@ module "api" {
 
 resource "aws_lambda_function_url" "api" {
   function_name      = module.api.function_name
-  authorization_type = "AWS_IAM"
+  authorization_type = "NONE"
 }

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -24,7 +24,3 @@ resource "aws_lambda_function_url" "api" {
   function_name      = module.api.function_name
   authorization_type = "AWS_IAM"
 }
-
-# Note: the aws_lambda_permission resources that grant CloudFront access to invoke
-# this function live in the CloudFront module. They reference the CloudFront
-# distribution ARN, so keeping them there avoids a circular Terragrunt dependency.

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -22,20 +22,9 @@ module "api" {
 
 resource "aws_lambda_function_url" "api" {
   function_name      = module.api.function_name
-  authorization_type = "NONE"
+  authorization_type = "AWS_IAM"
 }
 
-resource "aws_lambda_permission" "api_invoke_function_url" {
-  statement_id           = "AllowInvokeFunctionUrl"
-  action                 = "lambda:InvokeFunctionUrl"
-  function_name          = module.api.function_name
-  function_url_auth_type = "NONE"
-  principal              = "*"
-}
-
-resource "aws_lambda_permission" "api_invoke_function" {
-  statement_id  = "AllowInvokeFunction"
-  action        = "lambda:InvokeFunction"
-  function_name = module.api.function_name
-  principal     = "*"
-}
+# Note: the aws_lambda_permission resources that grant CloudFront access to invoke
+# this function live in the CloudFront module. They reference the CloudFront
+# distribution ARN, so keeping them there avoids a circular Terragrunt dependency.

--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -7,7 +7,6 @@ resource "aws_cloudfront_distribution" "api" {
   origin {
     domain_name              = split("/", var.api_function_url)[2]
     origin_id                = var.api_function_name
-    origin_access_control_id = aws_cloudfront_origin_access_control.secret_scanning.id
 
     custom_origin_config {
       http_port              = 80
@@ -121,12 +120,4 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_api" {
       protection = true
     }
   }
-}
-
-resource "aws_cloudfront_origin_access_control" "secret_scanning" {
-  name                              = var.product_name
-  description                       = "Limit invocation of the Lambda function to the CloudFront distribution"
-  origin_access_control_origin_type = "lambda"
-  signing_behavior                  = "always"
-  signing_protocol                  = "sigv4"
 }

--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -5,8 +5,8 @@ resource "aws_cloudfront_distribution" "api" {
   web_acl_id  = aws_wafv2_web_acl.api.arn
 
   origin {
-    domain_name              = split("/", var.api_function_url)[2]
-    origin_id                = var.api_function_name
+    domain_name = split("/", var.api_function_url)[2]
+    origin_id   = var.api_function_name
 
     custom_origin_config {
       http_port              = 80

--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -5,8 +5,9 @@ resource "aws_cloudfront_distribution" "api" {
   web_acl_id  = aws_wafv2_web_acl.api.arn
 
   origin {
-    domain_name = split("/", var.api_function_url)[2]
-    origin_id   = var.api_function_name
+    domain_name              = split("/", var.api_function_url)[2]
+    origin_id                = var.api_function_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.secret_scanning.id
 
     custom_origin_config {
       http_port              = 80
@@ -120,4 +121,12 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_api" {
       protection = true
     }
   }
+}
+
+resource "aws_cloudfront_origin_access_control" "secret_scanning" {
+  name                              = var.product_name
+  description                       = "Limit invocation of the Lambda function to the CloudFront distribution"
+  origin_access_control_origin_type = "lambda"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
 }

--- a/terragrunt/aws/cloudfront/lambda.tf
+++ b/terragrunt/aws/cloudfront/lambda.tf
@@ -1,0 +1,20 @@
+# Restrict invocation of the API Lambda function to this CloudFront distribution.
+# These permissions live in the CloudFront module (rather than the API module) to
+# avoid a circular Terragrunt dependency: the CloudFront distribution depends on
+# the API function URL/name, and these permissions depend on the distribution ARN.
+resource "aws_lambda_permission" "api_invoke_function_url" {
+  statement_id           = "AllowInvokeFunctionUrl"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = var.api_function_name
+  function_url_auth_type = "AWS_IAM"
+  principal              = "cloudfront.amazonaws.com"
+  source_arn             = aws_cloudfront_distribution.api.arn
+}
+
+resource "aws_lambda_permission" "api_invoke_function" {
+  statement_id  = "AllowInvokeFunction"
+  action        = "lambda:InvokeFunction"
+  function_name = var.api_function_name
+  principal     = "cloudfront.amazonaws.com"
+  source_arn    = aws_cloudfront_distribution.api.arn
+}

--- a/terragrunt/aws/cloudfront/lambda.tf
+++ b/terragrunt/aws/cloudfront/lambda.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_permission" "api_invoke_function_url" {
   statement_id           = "AllowInvokeFunctionUrl"
   action                 = "lambda:InvokeFunctionUrl"
   function_name          = var.api_function_name
-  function_url_auth_type = "AWS_IAM"
+  function_url_auth_type = "NONE"
   principal              = "cloudfront.amazonaws.com"
   source_arn             = aws_cloudfront_distribution.api.arn
 }


### PR DESCRIPTION
# Summary | Résumé

Locks down the API Lambda so it can only be invoked through the CloudFront distribution, replacing the previous public (principal = "*", auth NONE) access.

**Changes**

- Function URL → IAM auth: aws_lambda_function_url switched from authorization_type = "NONE" to "AWS_IAM".
- CloudFront Origin Access Control: added aws_cloudfront_origin_access_control (type lambda, sigv4, signing_behavior = always) and wired it into the origin via origin_access_control_id, so CloudFront SigV4-signs requests to the now IAM-protected function URL.
- Invoke permissions relocated to the CloudFront module: the aws_lambda_permission resources (InvokeFunctionUrl + InvokeFunction) now live in cloudfront/lambda.tf, scoped to principal = "cloudfront.amazonaws.com" with source_arn of the distribution.
